### PR TITLE
RxScala: Add from method to turn an Option into an Observable

### DIFF
--- a/src/main/scala/rx/lang/scala/Observable.scala
+++ b/src/main/scala/rx/lang/scala/Observable.scala
@@ -4571,6 +4571,22 @@ object Observable {
     toScalaObservable(rx.Observable.from(iterable.asJava, scheduler.asJavaScheduler))
   }
 
+  /**
+   * Converts an `Option` into an Observable.
+   *
+   * @param option the source `Option`
+   * @tparam T the type of item in the `Option` and the type of item
+   *           to be emitted by the resulting Observable
+   * @return an Observable that emits the item in the source `Option` or
+   *         an empty Observable if `Option` contains no item
+   */
+  def from[T](option: Option[T]): Observable[T] = {
+    option match {
+      case Some(v) => Observable.just(v)
+      case _ => Observable.empty
+    }
+  }
+
 
   /**
    * Returns an Observable that calls an Observable factory to create its Observable for each

--- a/src/test/scala/rx/lang/scala/ObservableTest.scala
+++ b/src/test/scala/rx/lang/scala/ObservableTest.scala
@@ -364,4 +364,15 @@ class ObservableTests extends JUnitSuite {
     assertEquals(false, Observable.empty.nonEmpty.toBlocking.single)
     assertEquals(true, Observable.just(1, 2, 3).nonEmpty.toBlocking.single)
   }
+
+  @Test
+  def testFromOptionWithItem(): Unit = {
+    val testItem = "test"
+    assertEquals(testItem, Observable.from(Some(testItem)).toBlocking.single)
+  }
+
+  @Test
+  def testFromOptionWithNone(): Unit = {
+    assertEquals(0, Observable.from(None).toBlocking.toList.size)
+  }
 }


### PR DESCRIPTION
I don't know if this is a common enough occurrence to warrant adding, but I often find myself writing this boilerplate code when jumping between collections (or other sources of optional's) and Observable code. So I thought it might be an useful addition.

The emitted Observable's are made to match the Scala behavior when doing flatMap on the result.
