### PR TITLE
Removes methods that also have a Scheduler parameter version by adding a default Scheduler

### DIFF
--- a/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala
+++ b/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala
@@ -682,7 +682,7 @@ class RxScalaDemo extends JUnitSuite {
   }
 
   @Test def timestampExample() {
-    val timestamped = Observable.interval(100 millis).take(6).timestamp.toBlocking
+    val timestamped = Observable.interval(100 millis).take(6).timestamp().toBlocking
     for ((millis, value) <- timestamped if value > 0) {
       println(value + " at t = " + millis)
     }
@@ -1284,7 +1284,7 @@ class RxScalaDemo extends JUnitSuite {
     val o = (1 to 10).toObservable
       .zip(Observable.interval(100 millis))
       .map(_._1)
-      .timeInterval
+      .timeInterval()
     println(o.toBlocking.toList)
   }
 

--- a/src/main/scala/rx/lang/scala/Observable.scala
+++ b/src/main/scala/rx/lang/scala/Observable.scala
@@ -18,6 +18,7 @@ package rx.lang.scala
 
 import rx.functions.FuncN
 import rx.lang.scala.observables.ConnectableObservable
+import rx.lang.scala.schedulers.{ImmediateScheduler, TrampolineScheduler, ComputationScheduler}
 import scala.concurrent.duration
 import java.util
 import collection.JavaConversions._
@@ -344,18 +345,6 @@ trait Observable[+T]
   }
 
   /**
-   * Wraps each item emitted by a source Observable in a timestamped tuple.
-   *
-   * <img width="640" src="https://github.com/Netflix/RxJava/wiki/images/rx-operators/timestamp.png">
-   *
-   * @return an Observable that emits timestamped items from the source Observable
-   */
-  def timestamp: Observable[(Long, T)] = {
-    toScalaObservable[rx.schedulers.Timestamped[_ <: T]](asJavaObservable.timestamp())
-      .map((t: rx.schedulers.Timestamped[_ <: T]) => (t.getTimestampMillis, t.getValue))
-  }
-
-  /**
    * Wraps each item emitted by a source Observable in a timestamped tuple
    * with timestamps provided by the given Scheduler.
    * <p>
@@ -365,7 +354,7 @@ trait Observable[+T]
    * @return an Observable that emits timestamped items from the source
    *         Observable with timestamps provided by the given Scheduler
    */
-  def timestamp(scheduler: Scheduler): Observable[(Long, T)] = {
+  def timestamp(scheduler: Scheduler = ImmediateScheduler()): Observable[(Long, T)] = {
     toScalaObservable[rx.schedulers.Timestamped[_ <: T]](asJavaObservable.timestamp(scheduler))
       .map((t: rx.schedulers.Timestamped[_ <: T]) => (t.getTimestampMillis, t.getValue))
   }
@@ -515,30 +504,12 @@ trait Observable[+T]
    * @param timespan
    *            The period of time each buffer is collecting values before it should be emitted, and
    *            replaced with a new buffer.
-   * @return
-   *         An [[rx.lang.scala.Observable]] which produces connected non-overlapping buffers with a fixed duration.
-   */
-  def tumblingBuffer(timespan: Duration): Observable[Seq[T]] = {
-    val oJava: rx.Observable[_ <: java.util.List[_]] = asJavaObservable.buffer(timespan.length, timespan.unit)
-    Observable.jObsOfListToScObsOfSeq(oJava.asInstanceOf[rx.Observable[_ <: java.util.List[T]]])
-  }
-
-  /**
-   * Creates an Observable which produces buffers of collected values.
-   *
-   * This Observable produces connected non-overlapping buffers, each of a fixed duration
-   * specified by the `timespan` argument. When the source Observable completes or encounters
-   * an error, the current buffer is emitted and the event is propagated.
-   *
-   * @param timespan
-   *            The period of time each buffer is collecting values before it should be emitted, and
-   *            replaced with a new buffer.
    * @param scheduler
    *            The [[rx.lang.scala.Scheduler]] to use when determining the end and start of a buffer.
    * @return
    *         An [[rx.lang.scala.Observable]] which produces connected non-overlapping buffers with a fixed duration.
    */
-  def tumblingBuffer(timespan: Duration, scheduler: Scheduler): Observable[Seq[T]] = {
+  def tumblingBuffer(timespan: Duration, scheduler: Scheduler = ComputationScheduler()): Observable[Seq[T]] = {
     val oJava: rx.Observable[_ <: java.util.List[_]] = asJavaObservable.buffer(timespan.length, timespan.unit, scheduler)
     Observable.jObsOfListToScObsOfSeq(oJava.asInstanceOf[rx.Observable[_ <: java.util.List[T]]])
   }
@@ -595,35 +566,13 @@ trait Observable[+T]
    *            The period of time each buffer is collecting values before it should be emitted.
    * @param timeshift
    *            The period of time after which a new buffer will be created.
-   * @return
-   *         An [[rx.lang.scala.Observable]] which produces new buffers periodically, and these are emitted after
-   *         a fixed timespan has elapsed.
-   */
-  def slidingBuffer(timespan: Duration, timeshift: Duration): Observable[Seq[T]] = {
-    val span: Long = timespan.length
-    val shift: Long = timespan.unit.convert(timeshift.length, timeshift.unit)
-    val unit: TimeUnit = timespan.unit
-    val oJava: rx.Observable[_ <: java.util.List[_]] = asJavaObservable.buffer(span, shift, unit)
-    Observable.jObsOfListToScObsOfSeq(oJava.asInstanceOf[rx.Observable[_ <: java.util.List[T]]])
-  }
-
-  /**
-   * Creates an Observable which produces buffers of collected values. This Observable starts a new buffer
-   * periodically, which is determined by the `timeshift` argument. Each buffer is emitted after a fixed timespan
-   * specified by the `timespan` argument. When the source Observable completes or encounters an error, the
-   * current buffer is emitted and the event is propagated.
-   *
-   * @param timespan
-   *            The period of time each buffer is collecting values before it should be emitted.
-   * @param timeshift
-   *            The period of time after which a new buffer will be created.
    * @param scheduler
    *            The [[rx.lang.scala.Scheduler]] to use when determining the end and start of a buffer.
    * @return
    *         An [[rx.lang.scala.Observable]] which produces new buffers periodically, and these are emitted after
    *         a fixed timespan has elapsed.
    */
-  def slidingBuffer(timespan: Duration, timeshift: Duration, scheduler: Scheduler): Observable[Seq[T]] = {
+  def slidingBuffer(timespan: Duration, timeshift: Duration, scheduler: Scheduler = ComputationScheduler()): Observable[Seq[T]] = {
     val span: Long = timespan.length
     val shift: Long = timespan.unit.convert(timeshift.length, timeshift.unit)
     val unit: TimeUnit = timespan.unit
@@ -756,28 +705,12 @@ trait Observable[+T]
    * @param timespan
    *            The period of time each window is collecting values before it should be emitted, and
    *            replaced with a new window.
-   * @return
-   *         An [[rx.lang.scala.Observable]] which produces connected non-overlapping windows with a fixed duration.
-   */
-  def tumbling(timespan: Duration): Observable[Observable[T]] = {
-    Observable.jObsOfJObsToScObsOfScObs(asJavaObservable.window(timespan.length, timespan.unit))
-      : Observable[Observable[T]] // SI-7818
-  }
-
-  /**
-   * Creates an Observable which produces windows of collected values. This Observable produces connected
-   * non-overlapping windows, each of a fixed duration specified by the `timespan` argument. When the source
-   * Observable completes or encounters an error, the current window is emitted and the event is propagated.
-   *
-   * @param timespan
-   *            The period of time each window is collecting values before it should be emitted, and
-   *            replaced with a new window.
    * @param scheduler
    *            The [[rx.lang.scala.Scheduler]] to use when determining the end and start of a window.
    * @return
    *         An [[rx.lang.scala.Observable]] which produces connected non-overlapping windows with a fixed duration.
    */
-  def tumbling(timespan: Duration, scheduler: Scheduler): Observable[Observable[T]] = {
+  def tumbling(timespan: Duration, scheduler: Scheduler = ComputationScheduler()): Observable[Observable[T]] = {
     Observable.jObsOfJObsToScObsOfScObs(asJavaObservable.window(timespan.length, timespan.unit, scheduler))
       : Observable[Observable[T]] // SI-7818
   }
@@ -834,35 +767,13 @@ trait Observable[+T]
    *            The period of time each window is collecting values before it should be emitted.
    * @param timeshift
    *            The period of time after which a new window will be created.
-   * @return
-   *         An [[rx.lang.scala.Observable]] which produces new windows periodically, and these are emitted after
-   *         a fixed timespan has elapsed.
-   */
-  def sliding(timespan: Duration, timeshift: Duration): Observable[Observable[T]] = {
-    val span: Long = timespan.length
-    val shift: Long = timespan.unit.convert(timeshift.length, timeshift.unit)
-    val unit: TimeUnit = timespan.unit
-    Observable.jObsOfJObsToScObsOfScObs(asJavaObservable.window(span, shift, unit))
-      : Observable[Observable[T]] // SI-7818
-  }
-
-  /**
-   * Creates an Observable which produces windows of collected values. This Observable starts a new window
-   * periodically, which is determined by the `timeshift` argument. Each window is emitted after a fixed timespan
-   * specified by the `timespan` argument. When the source Observable completes or encounters an error, the
-   * current window is emitted and the event is propagated.
-   *
-   * @param timespan
-   *            The period of time each window is collecting values before it should be emitted.
-   * @param timeshift
-   *            The period of time after which a new window will be created.
    * @param scheduler
    *            The [[rx.lang.scala.Scheduler]] to use when determining the end and start of a window.
    * @return
    *         An [[rx.lang.scala.Observable]] which produces new windows periodically, and these are emitted after
    *         a fixed timespan has elapsed.
    */
-  def sliding(timespan: Duration, timeshift: Duration, scheduler: Scheduler): Observable[Observable[T]] = {
+  def sliding(timespan: Duration, timeshift: Duration, scheduler: Scheduler = ComputationScheduler()): Observable[Observable[T]] = {
     val span: Long = timespan.length
     val shift: Long = timespan.unit.convert(timeshift.length, timeshift.unit)
     val unit: TimeUnit = timespan.unit
@@ -1281,13 +1192,25 @@ trait Observable[+T]
   }
 
   /**
-   * Returns a [[rx.lang.scala.observables.ConnectableObservable]] that shares a single subscription to the underlying
-   * Observable that will replay all of its items and notifications to any future [[rx.lang.scala.Observer]].
+   * Returns a `ConnectableObservable` that shares a single subscription to the underlying Observable
+   * that will replay all of its items and notifications to any future `Observer`. A Connectable
+   * Observable resembles an ordinary Observable, except that it does not begin emitting items when it is
+   * subscribed to, but only when its `connect` method is called.
+   * <p>
+   * <img width="640" height="515" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/replay.png" alt="">
+   * <dl>
+   *  <dt><b>Backpressure Support:</b></dt>
+   *  <dd>This operator does not support backpressure because multicasting means the stream is "hot" with
+   *      multiple subscribers. Each child will need to manage backpressure independently using operators such
+   *      as `#onBackpressureDrop` and `#onBackpressureBuffer`.</dd>
+   *  <dt><b>Scheduler:</b></dt>
+   *  <dd>This version of `replay` does not operate by default on a particular `Scheduler`.</dd>
+   * </dl>
    *
-   * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.png">
-   *
-   * @return a [[rx.lang.scala.observables.ConnectableObservable]] such that when the `connect` function
-   *         is called, the [[rx.lang.scala.observables.ConnectableObservable]] starts to emit items to its [[rx.lang.scala.Observer]]s
+   * @return a `ConnectableObservable` that upon connection causes the source Observable to emit its
+   *         items to its `Observer`s
+   * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Connectable-Observable-Operators#observablereplay">RxJava wiki: replay</a>
+   * @see <a href="http://msdn.microsoft.com/en-us/library/system.reactive.linq.observable.replay.aspx">MSDN: Observable.Replay</a>
    */
   def replay: ConnectableObservable[T] = {
     new ConnectableObservable[T](asJavaObservable.replay())
@@ -1337,28 +1260,6 @@ trait Observable[+T]
    * emitted by a `ConnectableObservable` that shares a single subscription to the source Observable,
    * replaying no more than `bufferSize` items that were emitted within a specified time window.
    * <p>
-   * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.fnt.png">
-   *
-   * @param selector  a selector function, which can use the multicasted sequence as many times as needed, without
-   *                  causing multiple subscriptions to the Observable
-   * @param bufferSize the buffer size that limits the number of items the connectable observable can replay
-   * @param time the duration of the window in which the replayed items must have been emitted
-   * @return an Observable that emits items that are the results of invoking the selector on items emitted by
-   *         a `ConnectableObservable` that shares a single subscription to the source Observable, and
-   *         replays no more than `bufferSize` items that were emitted within the window defined by `time`
-   */
-  def replay[R](selector: Observable[T] => Observable[R], bufferSize: Int, time: Duration): Observable[R] = {
-    val thisJava = this.asJavaObservable.asInstanceOf[rx.Observable[T]]
-    val fJava: Func1[rx.Observable[T], rx.Observable[R]] =
-      (jo: rx.Observable[T]) => selector(toScalaObservable[T](jo)).asJavaObservable.asInstanceOf[rx.Observable[R]]
-    toScalaObservable[R](thisJava.replay(fJava, bufferSize, time.length, time.unit))
-  }
-
-  /**
-   * Returns an Observable that emits items that are the results of invoking a specified selector on items
-   * emitted by a `ConnectableObservable` that shares a single subscription to the source Observable,
-   * replaying no more than `bufferSize` items that were emitted within a specified time window.
-   * <p>
    * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.fnts.png">
    *
    * @param selector  a selector function, which can use the multicasted sequence as many times as needed, without
@@ -1371,7 +1272,7 @@ trait Observable[+T]
    *         replays no more than `bufferSize` items that were emitted within the window defined by `time`
    * @throws IllegalArgumentException if `bufferSize` is less than zero
    */
-  def replay[R](selector: Observable[T] => Observable[R], bufferSize: Int, time: Duration, scheduler: Scheduler): Observable[R] = {
+  def replay[R](selector: Observable[T] => Observable[R], bufferSize: Int, time: Duration, scheduler: Scheduler = ComputationScheduler()): Observable[R] = {
     val thisJava = this.asJavaObservable.asInstanceOf[rx.Observable[T]]
     val fJava: Func1[rx.Observable[T], rx.Observable[R]] =
       (jo: rx.Observable[T]) => selector(toScalaObservable[T](jo)).asJavaObservable.asInstanceOf[rx.Observable[R]]
@@ -1407,9 +1308,31 @@ trait Observable[+T]
    * <p>
    * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.ft.png">
    *
+   * @param selector  a selector function, which can use the multicasted sequence as many times as needed, without
+   *                  causing multiple subscriptions to the Observable
+   * @param time the duration of the window in which the replayed items must have been emitted
+   * @return an Observable that emits items that are the results of invoking the selector on items emitted by
+   *         a `ConnectableObservable` that shares a single subscription to the source Observable,
+   *         replaying all items that were emitted within the window defined by `time`
+   */
+  def replay[R](selector: Observable[T] => Observable[R], time: Duration): Observable[R] = {
+    val thisJava = this.asJavaObservable.asInstanceOf[rx.Observable[T]]
+    val fJava: Func1[rx.Observable[T], rx.Observable[R]] =
+      (jo: rx.Observable[T]) => selector(toScalaObservable[T](jo)).asJavaObservable.asInstanceOf[rx.Observable[R]]
+    toScalaObservable[R](thisJava.replay(fJava, time.length, time.unit))
+  }
+
+  /**
+   * Returns an Observable that emits items that are the results of invoking a specified selector on items
+   * emitted by a `ConnectableObservable` that shares a single subscription to the source Observable,
+   * replaying all items that were emitted within a specified time window.
+   * <p>
+   * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.ft.png">
+   *
    * @param selector   a selector function, which can use the multicasted sequence as many times as needed, without
    *                   causing multiple subscriptions to the Observable
    * @param time  the duration of the window in which the replayed items must have been emitted
+   * @param scheduler  the Scheduler on which the replay is observed
    * @return an Observable that emits items that are the results of invoking the selector on items emitted by
    *         a `ConnectableObservable` that shares a single subscription to the source Observable,
    *         replaying all items that were emitted within the window defined by `time`
@@ -1474,35 +1397,27 @@ trait Observable[+T]
   }
 
   /**
-   * Returns an Observable that emits items that are the results of invoking a specified selector on items
-   * emitted by a `ConnectableObservable` that shares a single subscription to the source Observable,
-   * replaying all items that were emitted within a specified time window.
-   * <p>
-   * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.ft.png">
-   *
-   * @param selector  a selector function, which can use the multicasted sequence as many times as needed, without
-   *                  causing multiple subscriptions to the Observable
-   * @param time the duration of the window in which the replayed items must have been emitted
-   * @return an Observable that emits items that are the results of invoking the selector on items emitted by
-   *         a `ConnectableObservable` that shares a single subscription to the source Observable,
-   *         replaying all items that were emitted within the window defined by `time`
-   */
-  def replay[R](selector: Observable[T] => Observable[R], time: Duration): Observable[R] = {
-    val thisJava = this.asJavaObservable.asInstanceOf[rx.Observable[T]]
-    val fJava: Func1[rx.Observable[T], rx.Observable[R]] =
-      (jo: rx.Observable[T]) => selector(toScalaObservable[T](jo)).asJavaObservable.asInstanceOf[rx.Observable[R]]
-    toScalaObservable[R](thisJava.replay(fJava, time.length, time.unit))
-  }
-
-  /**
    * Returns a `ConnectableObservable` that shares a single subscription to the source Observable that
-   * replays at most `bufferSize` items emitted by that Observable.
+   * replays at most `bufferSize` items emitted by that Observable. A Connectable Observable resembles
+   * an ordinary Observable, except that it does not begin emitting items when it is subscribed to, but only
+   * when its `connect` method is called.
    * <p>
-   * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/replay.n.png">
+   * <img width="640" height="515" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/replay.n.png" alt="">
+   * <dl>
+   *  <dt><b>Backpressure Support:</b></dt>
+   *  <dd>This operator does not support backpressure because multicasting means the stream is "hot" with
+   *      multiple subscribers. Each child will need to manage backpressure independently using operators such
+   *      as `#onBackpressureDrop` and `#onBackpressureBuffer`.</dd>
+   *  <dt><b>Scheduler:</b></dt>
+   *  <dd>This version of `replay` does not operate by default on a particular `Scheduler`.</dd>
+   * </dl>
    *
-   * @param bufferSize the buffer size that limits the number of items that can be replayed
-   * @return a `ConnectableObservable` that shares a single subscription to the source Observable and
-   *         replays at most `bufferSize` items emitted by that Observable
+   * @param bufferSize
+     *            the buffer size that limits the number of items that can be replayed
+   * @return a {@link ConnectableObservable} that shares a single subscription to the source Observable and
+   *         replays at most {@code bufferSize} items emitted by that Observable
+   * @see <a href="https://github.com/ReactiveX/RxJava/wiki/Connectable-Observable-Operators#observablereplay">RxJava wiki: replay</a>
+   * @see <a href="http://msdn.microsoft.com/en-us/library/hh211976.aspx">MSDN: Observable.Replay</a>
    */
   def replay(bufferSize: Int): ConnectableObservable[T] = {
     new ConnectableObservable[T](asJavaObservable.replay(bufferSize))
@@ -1794,26 +1709,12 @@ trait Observable[+T]
    * <img width="640" src="https://github.com/Netflix/RxJava/wiki/images/rx-operators/sample.png">
    *
    * @param duration the sampling rate
-   * @return an Observable that emits the results of sampling the items emitted by the source
-   *         Observable at the specified time interval
-   */
-  def sample(duration: Duration): Observable[T] = {
-    toScalaObservable[T](asJavaObservable.sample(duration.length, duration.unit))
-  }
-
-  /**
-   * Returns an Observable that emits the results of sampling the items emitted by the source
-   * Observable at a specified time interval.
-   *
-   * <img width="640" src="https://github.com/Netflix/RxJava/wiki/images/rx-operators/sample.png">
-   *
-   * @param duration the sampling rate
    * @param scheduler
    *            the [[rx.lang.scala.Scheduler]] to use when sampling
    * @return an Observable that emits the results of sampling the items emitted by the source
    *         Observable at the specified time interval
    */
-  def sample(duration: Duration, scheduler: Scheduler): Observable[T] = {
+  def sample(duration: Duration, scheduler: Scheduler = ComputationScheduler()): Observable[T] = {
     toScalaObservable[T](asJavaObservable.sample(duration.length, duration.unit, scheduler))
   }
 
@@ -1920,25 +1821,11 @@ trait Observable[+T]
    * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/skip.t.png">
    *
    * @param time the length of the time window to drop
-   * @return an Observable that drops values emitted by the source Observable before the time window defined
-   *         by `time` elapses and emits the remainder
-   */
-  def drop(time: Duration): Observable[T] = {
-    toScalaObservable(asJavaObservable.skip(time.length, time.unit))
-  }
-
-  /**
-   * Returns an Observable that drops values emitted by the source Observable before a specified time window
-   * elapses.
-   *
-   * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/skip.t.png">
-   *
-   * @param time the length of the time window to drop
    * @param scheduler the `Scheduler` on which the timed wait happens
    * @return an Observable that drops values emitted by the source Observable before the time window defined
    *         by `time` elapses and emits the remainder
    */
-  def drop(time: Duration, scheduler: Scheduler): Observable[T] = {
+  def drop(time: Duration, scheduler: Scheduler = ComputationScheduler()): Observable[T] = {
     toScalaObservable(asJavaObservable.skip(time.length, time.unit, scheduler))
   }
 
@@ -1978,22 +1865,6 @@ trait Observable[+T]
 
   /**
    * Returns an Observable that drops items emitted by the source Observable during a specified time window
-   * before the source completes.
-   * <p>
-   * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/skipLast.t.png">
-   *
-   * Note: this action will cache the latest items arriving in the specified time window.
-   *
-   * @param time the length of the time window
-   * @return an Observable that drops those items emitted by the source Observable in a time window before the
-   *         source completes defined by `time`
-   */
-  def dropRight(time: Duration): Observable[T] = {
-    toScalaObservable(asJavaObservable.skipLast(time.length, time.unit))
-  }
-
-  /**
-   * Returns an Observable that drops items emitted by the source Observable during a specified time window
    * (defined on a specified scheduler) before the source completes.
    * <p>
    * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/skipLast.ts.png">
@@ -2005,7 +1876,7 @@ trait Observable[+T]
    * @return an Observable that drops those items emitted by the source Observable in a time window before the
    *         source completes defined by `time` and `scheduler`
    */
-  def dropRight(time: Duration, scheduler: Scheduler): Observable[T] = {
+  def dropRight(time: Duration, scheduler: Scheduler = ComputationScheduler()): Observable[T] = {
     toScalaObservable(asJavaObservable.skipLast(time.length, time.unit, scheduler))
   }
 
@@ -2106,20 +1977,6 @@ trait Observable[+T]
 
   /**
    * Return an Observable that emits the items from the source Observable that were emitted in a specified
-   * window of `time` before the Observable completed.
-   * <p>
-   * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/takeLast.t.png">
-   *
-   * @param time the length of the time window
-   * @return an Observable that emits the items from the source Observable that were emitted in the window of
-   *         time before the Observable completed specified by `time`
-   */
-  def takeRight(time: Duration): Observable[T] = {
-    toScalaObservable[T](asJavaObservable.takeLast(time.length, time.unit))
-  }
-
-  /**
-   * Return an Observable that emits the items from the source Observable that were emitted in a specified
    * window of `time` before the Observable completed, where the timing information is provided by a specified
    * Scheduler.
    * <p>
@@ -2131,7 +1988,7 @@ trait Observable[+T]
    *         time before the Observable completed specified by `time`, where the timing information is
    *         provided by `scheduler`
    */
-  def takeRight(time: Duration, scheduler: Scheduler): Observable[T] = {
+  def takeRight(time: Duration, scheduler: Scheduler = ComputationScheduler()): Observable[T] = {
     toScalaObservable[T](asJavaObservable.takeLast(time.length, time.unit, scheduler.asJavaScheduler))
   }
 
@@ -2564,31 +2421,12 @@ trait Observable[+T]
    *
    * @param timeout
    *            The time each value has to be 'the most recent' of the [[rx.lang.scala.Observable]] to ensure that it's not dropped.
-   *
-   * @return An [[rx.lang.scala.Observable]] which filters out values which are too quickly followed up with newer values.
-   * @see `Observable.throttleWithTimeout`
-   */
-  def debounce(timeout: Duration): Observable[T] = {
-    toScalaObservable[T](asJavaObservable.debounce(timeout.length, timeout.unit))
-  }
-
-  /**
-   * Debounces by dropping all values that are followed by newer values before the timeout value expires. The timer resets on each `onNext` call.
-   *
-   * NOTE: If events keep firing faster than the timeout then no data will be emitted.
-   *
-   * <img width="640" src="https://github.com/Netflix/RxJava/wiki/images/rx-operators/debounce.png">
-   *
-   * $debounceVsThrottle
-   *
-   * @param timeout
-   *            The time each value has to be 'the most recent' of the [[rx.lang.scala.Observable]] to ensure that it's not dropped.
    * @param scheduler
    *            The [[rx.lang.scala.Scheduler]] to use internally to manage the timers which handle timeout for each event.
    * @return Observable which performs the throttle operation.
    * @see `Observable.throttleWithTimeout`
    */
-  def debounce(timeout: Duration, scheduler: Scheduler): Observable[T] = {
+  def debounce(timeout: Duration, scheduler: Scheduler = ComputationScheduler()): Observable[T] = {
     toScalaObservable[T](asJavaObservable.debounce(timeout.length, timeout.unit, scheduler))
   }
 
@@ -2606,7 +2444,7 @@ trait Observable[+T]
    * @return Observable which performs the throttle operation.
    * @see `Observable.debounce`
    */
-  def throttleWithTimeout(timeout: Duration, scheduler: Scheduler): Observable[T] = {
+  def throttleWithTimeout(timeout: Duration, scheduler: Scheduler = ComputationScheduler()): Observable[T] = {
     toScalaObservable[T](asJavaObservable.throttleWithTimeout(timeout.length, timeout.unit, scheduler))
   }
 
@@ -2623,7 +2461,7 @@ trait Observable[+T]
    *            The [[rx.lang.scala.Scheduler]] to use internally to manage the timers which handle timeout for each event.
    * @return Observable which performs the throttle operation.
    */
-  def throttleFirst(skipDuration: Duration, scheduler: Scheduler): Observable[T] = {
+  def throttleFirst(skipDuration: Duration, scheduler: Scheduler = ComputationScheduler()): Observable[T] = {
     toScalaObservable[T](asJavaObservable.throttleFirst(skipDuration.length, skipDuration.unit, scheduler))
   }
 
@@ -2653,22 +2491,7 @@ trait Observable[+T]
    *            Duration of windows within with the last value will be chosen.
    * @return Observable which performs the throttle operation.
    */
-  def throttleLast(intervalDuration: Duration): Observable[T] = {
-    toScalaObservable[T](asJavaObservable.throttleLast(intervalDuration.length, intervalDuration.unit))
-  }
-
-  /**
-   * Throttles by returning the last value of each interval defined by 'intervalDuration'.
-   *
-   * This differs from `Observable.throttleFirst` in that this ticks along at a scheduled interval whereas `Observable.throttleFirst` does not tick, it just tracks passage of time.
-   *
-   * <img width="640" src="https://github.com/Netflix/RxJava/wiki/images/rx-operators/throttleLast.png">
-   *
-   * @param intervalDuration
-   *            Duration of windows within with the last value will be chosen.
-   * @return Observable which performs the throttle operation.
-   */
-  def throttleLast(intervalDuration: Duration, scheduler: Scheduler): Observable[T] = {
+  def throttleLast(intervalDuration: Duration, scheduler: Scheduler = ComputationScheduler()): Observable[T] = {
     toScalaObservable[T](asJavaObservable.throttleLast(intervalDuration.length, intervalDuration.unit, scheduler))
   }
 
@@ -2676,16 +2499,17 @@ trait Observable[+T]
    * Applies a timeout policy for each item emitted by the Observable, using
    * the specified scheduler to run timeout timers. If the next item isn't
    * observed within the specified timeout duration starting from its
-   * predecessor, observers are notified of a `TimeoutException`.
+   * predecessor, the observer is notified of a `TimeoutException`.
    * <p>
-   * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timeout.1.png">
+   * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timeout.1s.png">
    *
    * @param timeout maximum duration between items before a timeout occurs
+   * @param scheduler Scheduler to run the timeout timers on
    * @return the source Observable modified to notify observers of a
    *         `TimeoutException` in case of a timeout
    */
-  def timeout(timeout: Duration): Observable[T] = {
-    toScalaObservable[T](asJavaObservable.timeout(timeout.length, timeout.unit))
+  def timeout(timeout: Duration, scheduler: Scheduler = ComputationScheduler()): Observable[T] = {
+    toScalaObservable[T](asJavaObservable.timeout(timeout.length, timeout.unit, scheduler.asJavaScheduler))
   }
 
   /**
@@ -2706,23 +2530,6 @@ trait Observable[+T]
     val otherJava: rx.Observable[_ <: U] = other.asJavaObservable
     val thisJava = this.asJavaObservable.asInstanceOf[rx.Observable[U]]
     toScalaObservable[U](thisJava.timeout(timeout.length, timeout.unit, otherJava))
-  }
-
-  /**
-   * Applies a timeout policy for each item emitted by the Observable, using
-   * the specified scheduler to run timeout timers. If the next item isn't
-   * observed within the specified timeout duration starting from its
-   * predecessor, the observer is notified of a `TimeoutException`.
-   * <p>
-   * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timeout.1s.png">
-   *
-   * @param timeout maximum duration between items before a timeout occurs
-   * @param scheduler Scheduler to run the timeout timers on
-   * @return the source Observable modified to notify observers of a
-   *         `TimeoutException` in case of a timeout
-   */
-  def timeout(timeout: Duration, scheduler: Scheduler): Observable[T] = {
-    toScalaObservable[T](asJavaObservable.timeout(timeout.length, timeout.unit, scheduler.asJavaScheduler))
   }
 
   /**
@@ -3212,18 +3019,12 @@ trait Observable[+T]
   }
 
   /**
-   * Returns an Observable that emits the same values as the source observable with the exception of an
-   * `onError`. An `onError` notification from the source will result in the emission of a
-   * [[Throwable]] to the Observable provided as an argument to the `notificationHandler`
-   * function. If the Observable returned `onCompletes` or `onErrors` then `retry` will call
-   * `onCompleted` or `onError` on the child subscription. Otherwise, this Observable will
-   * resubscribe to the source Observable.
+   * Returns an Observable that emits the same values as the source observable with the exception of an `onError`.
+   * An onError will emit a [[Throwable]] to the Observable provided as an argument to the notificationHandler
+   * func. If the Observable returned `onCompletes` or `onErrors` then retry will call `onCompleted`
+   * or `onError` on the child subscription. Otherwise, this observable will resubscribe to the source observable, on a particular Scheduler.
    * <p>
    * <img width="640" height="430" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/retryWhen.f.png" alt="">
-   *
-   * Example:
-   *
-   * This retries 3 times, each time incrementing the number of seconds it waits.
    *
    * @example
    *
@@ -3252,37 +3053,6 @@ trait Observable[+T]
    * delay retry by 3 second(s)
    * subscribing
    * }}}
-   *
-   * <dl>
-   *  <dt><b>Scheduler:</b></dt>
-   *  <dd>`retryWhen` operates by default on the `trampoline` [[Scheduler]].</dd>
-   * </dl>
-   *
-   * @param notificationHandler receives an Observable of a Throwable with which a user can complete or error, aborting the
-   *            retry
-   * @return the source Observable modified with retry logic
-   * @see <a href="https://github.com/Netflix/RxJava/wiki/Error-Handling-Operators#retrywhen">RxJava Wiki: retryWhen()</a>
-   * @see RxScalaDemo.retryWhenDifferentExceptionsExample for a more intricate example
-   * @since 0.20
-   */
-  def retryWhen(notificationHandler: Observable[Throwable] => Observable[Any]): Observable[T] = {
-    val f: Func1[_ >: rx.Observable[_ <: Throwable], _ <: rx.Observable[_ <: Any]] =
-      (jOt: rx.Observable[_ <: Throwable]) => {
-        val ot = toScalaObservable[Throwable](jOt)
-        notificationHandler(ot).asJavaObservable
-      }
-
-    toScalaObservable[T](asJavaObservable.retryWhen(f))
-  }
-
-  /**
-   * Returns an Observable that emits the same values as the source observable with the exception of an `onError`.
-   * An onError will emit a [[Throwable]] to the Observable provided as an argument to the notificationHandler
-   * func. If the Observable returned `onCompletes` or `onErrors` then retry will call `onCompleted`
-   * or `onError` on the child subscription. Otherwise, this observable will resubscribe to the source observable, on a particular Scheduler.
-   * <p>
-   * <img width="640" height="430" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/retryWhen.f.png" alt="">
-   * <p>
    * <dl>
    *  <dt><b>Scheduler:</b></dt>
    *  <dd>you specify which [[Scheduler]] this operator will use</dd>
@@ -3296,7 +3066,7 @@ trait Observable[+T]
    * @see RxScalaDemo.retryWhenDifferentExceptionsExample for a more intricate example
    * @since 0.20
    */
-  def retryWhen(notificationHandler: Observable[Throwable] => Observable[Any], scheduler: Scheduler): Observable[T] = {
+  def retryWhen(notificationHandler: Observable[Throwable] => Observable[Any], scheduler: Scheduler = TrampolineScheduler()): Observable[T] = {
     val f: Func1[_ >: rx.Observable[_ <: Throwable], _ <: rx.Observable[_ <: Any]] =
       (jOt: rx.Observable[_ <: Throwable]) => {
         val ot = toScalaObservable[Throwable](jOt)
@@ -3335,22 +3105,6 @@ trait Observable[+T]
   }
 
   /**
-   * Returns an Observable that repeats the sequence of items emitted by the source Observable at most `count` times.
-   * <p>
-   * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/repeat.on.png">
-   *
-   * @param count the number of times the source Observable items are repeated,
-   *              a count of 0 will yield an empty sequence
-   * @return an Observable that repeats the sequence of items emitted by the source Observable at most `count` times
-   * @throws IllegalArgumentException if `count` is less than zero
-   * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#wiki-repeat">RxJava Wiki: repeat()</a>
-   * @see <a href="http://msdn.microsoft.com/en-us/library/hh229428.aspx">MSDN: Observable.Repeat</a>
-   */
-  def repeat(count: Long): Observable[T] = {
-    toScalaObservable[T](asJavaObservable.repeat(count))
-  }
-
-  /**
    * Returns an Observable that repeats the sequence of items emitted by the source Observable
    * at most `count` times, on a particular Scheduler.
    * <p>
@@ -3364,7 +3118,7 @@ trait Observable[+T]
    * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#wiki-repeat">RxJava Wiki: repeat()</a>
    * @see <a href="http://msdn.microsoft.com/en-us/library/hh229428.aspx">MSDN: Observable.Repeat</a>
    */
-  def repeat(count: Long, scheduler: Scheduler): Observable[T] = {
+  def repeat(count: Long, scheduler: Scheduler = TrampolineScheduler()): Observable[T] = {
     toScalaObservable[T](asJavaObservable.repeat(count, scheduler))
   }
 
@@ -3375,37 +3129,6 @@ trait Observable[+T]
    * function. If the Observable returned `onCompletes` or `onErrors` then `repeatWhen` will
    * call `onCompleted` or `onError` on the child subscription. Otherwise, this Observable will
    * resubscribe to the source Observable, on a particular Scheduler.
-   * <p>
-   * <img width="640" height="430" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/repeatWhen.f.png" alt="">
-   * <dl>
-   *  <dt><b>Scheduler:</b></dt>
-   *  <dd>you specify which [[Scheduler]] this operator will use</dd>
-   * </dl>
-   *
-   * @param notificationHandler receives an Observable of a Unit with which a user can complete or error, aborting the repeat.
-   * @param scheduler the Scheduler to emit the items on
-   * @return the source Observable modified with repeat logic
-   * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#repeatwhen">RxJava Wiki: repeatWhen()</a>
-   * @see <a href="http://msdn.microsoft.com/en-us/library/hh229428.aspx">MSDN: Observable.Repeat</a>
-   * @since 0.20
-   */
-  def repeatWhen(notificationHandler: Observable[Unit] => Observable[Any], scheduler: Scheduler): Observable[T] = {
-    val f: Func1[_ >: rx.Observable[_ <: Void], _ <: rx.Observable[_ <: Any]] =
-      (jOv: rx.Observable[_ <: Void]) => {
-        val ov = toScalaObservable[Void](jOv)
-        notificationHandler(ov.map( _ => Unit )).asJavaObservable
-      }
-
-    toScalaObservable[T](asJavaObservable.repeatWhen(f, scheduler))
-  }
-
-  /**
-   * Returns an Observable that emits the same values as the source Observable with the exception of an
-   * `onCompleted`. An `onCompleted` notification from the source will result in the emission of
-   * a [[scala.Unit]] to the Observable provided as an argument to the `notificationHandler`
-   * function. If the Observable returned `onCompletes` or `onErrors` then `repeatWhen` will
-   * call `onCompleted` or `onError` on the child subscription. Otherwise, this Observable will
-   * resubscribe to the source observable.
    * <p>
    * <img width="640" height="430" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/repeatWhen.f.png" alt="">
    *
@@ -3436,26 +3159,26 @@ trait Observable[+T]
    * delay repeat by 3 second(s)
    * subscribing
    * }}}
-   *
    * <dl>
    *  <dt><b>Scheduler:</b></dt>
-   *  <dd>`repeatWhen` operates by default on the `trampoline` [[Scheduler]].</dd>
+   *  <dd>you specify which [[Scheduler]] this operator will use</dd>
    * </dl>
    *
    * @param notificationHandler receives an Observable of a Unit with which a user can complete or error, aborting the repeat.
+   * @param scheduler the Scheduler to emit the items on
    * @return the source Observable modified with repeat logic
    * @see <a href="https://github.com/Netflix/RxJava/wiki/Creating-Observables#repeatwhen">RxJava Wiki: repeatWhen()</a>
    * @see <a href="http://msdn.microsoft.com/en-us/library/hh229428.aspx">MSDN: Observable.Repeat</a>
    * @since 0.20
    */
-  def repeatWhen(notificationHandler: Observable[Unit] => Observable[Any]): Observable[T] = {
+  def repeatWhen(notificationHandler: Observable[Unit] => Observable[Any], scheduler: Scheduler = TrampolineScheduler()): Observable[T] = {
     val f: Func1[_ >: rx.Observable[_ <: Void], _ <: rx.Observable[_ <: Any]] =
       (jOv: rx.Observable[_ <: Void]) => {
         val ov = toScalaObservable[Void](jOv)
         notificationHandler(ov.map( _ => Unit )).asJavaObservable
       }
 
-    toScalaObservable[T](asJavaObservable.repeatWhen(f))
+    toScalaObservable[T](asJavaObservable.repeatWhen(f, scheduler))
   }
 
   /**
@@ -3655,26 +3378,13 @@ trait Observable[+T]
    * Returns an Observable that emits the items emitted by the source Observable shifted forward in time by a
    * specified delay. Error notifications from the source Observable are not delayed.
    *
-   * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/delay.png">
-   * 
-   * @param delay the delay to shift the source by
-   * @return the source Observable shifted in time by the specified delay
-   */
-  def delay(delay: Duration): Observable[T] = {
-    toScalaObservable[T](asJavaObservable.delay(delay.length, delay.unit))
-  }
-
-  /**
-   * Returns an Observable that emits the items emitted by the source Observable shifted forward in time by a
-   * specified delay. Error notifications from the source Observable are not delayed.
-   *
    * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/delay.s.png">
    * 
    * @param delay the delay to shift the source by
    * @param scheduler the Scheduler to use for delaying
    * @return the source Observable shifted in time by the specified delay
    */
-  def delay(delay: Duration, scheduler: Scheduler): Observable[T] = {
+  def delay(delay: Duration, scheduler: Scheduler = ComputationScheduler()): Observable[T] = {
     toScalaObservable[T](asJavaObservable.delay(delay.length, delay.unit, scheduler))
   }
 
@@ -3730,18 +3440,6 @@ trait Observable[+T]
   }
 
   /**
-   * Return an Observable that delays the subscription to the source Observable by a given amount of time.
-   *
-   * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/delaySubscription.png">
-   * 
-   * @param delay the time to delay the subscription
-   * @return an Observable that delays the subscription to the source Observable by the given amount
-   */
-  def delaySubscription(delay: Duration): Observable[T] = {
-    toScalaObservable[T](asJavaObservable.delaySubscription(delay.length, delay.unit))
-  }
-
-  /**
    * Return an Observable that delays the subscription to the source Observable by a given amount of time,
    * both waiting and subscribing on a given Scheduler.
    *
@@ -3752,7 +3450,7 @@ trait Observable[+T]
    * @return an Observable that delays the subscription to the source Observable by a given
    *         amount, waiting and subscribing on the given Scheduler
    */
-  def delaySubscription(delay: Duration, scheduler: Scheduler): Observable[T] = {
+  def delaySubscription(delay: Duration, scheduler: Scheduler = ComputationScheduler()): Observable[T] = {
     toScalaObservable[T](asJavaObservable.delaySubscription(delay.length, delay.unit, scheduler))
   }
 
@@ -3890,19 +3588,6 @@ trait Observable[+T]
 
   /**
    * Returns an Observable that emits records of the time interval between consecutive items emitted by the
-   * source Obsegrvable.
-   * <p>
-   * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timeInterval.png">
-   *
-   * @return an Observable that emits time interval information items
-   */
-  def timeInterval: Observable[(Duration, T)] = {
-    toScalaObservable(asJavaObservable.timeInterval())
-      .map(inv => (Duration(inv.getIntervalInMilliseconds, MILLISECONDS), inv.getValue))
-  }
-
-  /**
-   * Returns an Observable that emits records of the time interval between consecutive items emitted by the
    * source Observable, where this interval is computed on a specified Scheduler.
    * <p>
    * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timeInterval.s.png">
@@ -3910,7 +3595,7 @@ trait Observable[+T]
    * @param scheduler the [[Scheduler]] used to compute time intervals
    * @return an Observable that emits time interval information items
    */
-  def timeInterval(scheduler: Scheduler): Observable[(Duration, T)] = {
+  def timeInterval(scheduler: Scheduler = ImmediateScheduler()): Observable[(Duration, T)] = {
     toScalaObservable(asJavaObservable.timeInterval(scheduler.asJavaScheduler))
       .map(inv => (Duration(inv.getIntervalInMilliseconds, MILLISECONDS), inv.getValue))
   }
@@ -4631,26 +4316,13 @@ object Observable {
    *
    * <img width="640" src="https://github.com/Netflix/RxJava/wiki/images/rx-operators/interval.png">
    *
-   * @param duration
-   *            duration between two consecutive numbers
-   * @return An Observable that emits a number each time interval.
-   */
-  def interval(duration: Duration): Observable[Long] = {
-    toScalaObservable[java.lang.Long](rx.Observable.interval(duration.length, duration.unit)).map(_.longValue())
-  }
-
-  /**
-   * Emits `0`, `1`, `2`, `...` with a delay of `duration` between consecutive numbers.
-   *
-   * <img width="640" src="https://github.com/Netflix/RxJava/wiki/images/rx-operators/interval.png">
-   *
    * @param period
    *            duration between two consecutive numbers
    * @param scheduler
    *            the scheduler to use
    * @return An Observable that emits a number each time interval.
    */
-  def interval(period: Duration, scheduler: Scheduler): Observable[Long] = {
+  def interval(period: Duration, scheduler: Scheduler = ComputationScheduler()): Observable[Long] = {
     toScalaObservable[java.lang.Long](rx.Observable.interval(period.length, period.unit, scheduler)).map(_.longValue())
   }
 
@@ -4691,18 +4363,6 @@ object Observable {
   }
 
   /**
-   * Returns an Observable that emits `0L` after a specified delay, and then completes.
-   *
-   * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/timer.png">
-   *
-   * @param delay the initial delay before emitting a single `0L`
-   * @return Observable that emits `0L` after a specified delay, and then completes
-   */
-  def timer(delay: Duration): Observable[Long] = {
-    toScalaObservable[java.lang.Long](rx.Observable.timer(delay.length, delay.unit)).map(_.longValue())
-  }
-
-  /**
    * Returns an Observable that emits `0L` after a specified delay, on a specified Scheduler, and then
    * completes.
    *
@@ -4712,7 +4372,7 @@ object Observable {
    * @param scheduler the Scheduler to use for scheduling the item
    * @return Observable that emits `0L` after a specified delay, on a specified Scheduler, and then completes
    */
-  def timer(delay: Duration, scheduler: Scheduler): Observable[Long] = {
+  def timer(delay: Duration, scheduler: Scheduler = ComputationScheduler()): Observable[Long] = {
     toScalaObservable[java.lang.Long](rx.Observable.timer(delay.length, delay.unit, scheduler)).map(_.longValue())
   }
 

--- a/src/test/scala/rx/lang/scala/CompletenessTest.scala
+++ b/src/test/scala/rx/lang/scala/CompletenessTest.scala
@@ -68,11 +68,11 @@ class CompletenessTest extends JUnitSuite {
       "asObservable()" -> unnecessary,
       "buffer(Int)" -> "tumblingBuffer(Int)",
       "buffer(Int, Int)" -> "slidingBuffer(Int, Int)",
-      "buffer(Long, TimeUnit)" -> "tumblingBuffer(Duration)",
+      "buffer(Long, TimeUnit)" -> "tumblingBuffer(Duration, Scheduler)",
       "buffer(Long, TimeUnit, Int)" -> "tumblingBuffer(Duration, Int)",
       "buffer(Long, TimeUnit, Int, Scheduler)" -> "tumblingBuffer(Duration, Int, Scheduler)",
       "buffer(Long, TimeUnit, Scheduler)" -> "tumblingBuffer(Duration, Scheduler)",
-      "buffer(Long, Long, TimeUnit)" -> "slidingBuffer(Duration, Duration)",
+      "buffer(Long, Long, TimeUnit)" -> "slidingBuffer(Duration, Duration, Scheduler)",
       "buffer(Long, Long, TimeUnit, Scheduler)" -> "slidingBuffer(Duration, Duration, Scheduler)",
       "buffer(Func0[_ <: Observable[_ <: TClosing]])" -> "tumblingBuffer(=> Observable[Any])",
       "buffer(Observable[B])" -> "tumblingBuffer(=> Observable[Any])",
@@ -85,9 +85,12 @@ class CompletenessTest extends JUnitSuite {
       "contains(Any)" -> "contains(U)",
       "count()" -> "length",
       "debounce(Func1[_ >: T, _ <: Observable[U]])" -> "debounce(T => Observable[Any])",
+      "debounce(Long, TimeUnit)" -> "debounce(Duration, Scheduler)",
       "defaultIfEmpty(T)" -> "orElse(=> U)",
       "delay(Func0[_ <: Observable[U]], Func1[_ >: T, _ <: Observable[V]])" -> "delay(() => Observable[Any], T => Observable[Any])",
       "delay(Func1[_ >: T, _ <: Observable[U]])" -> "delay(T => Observable[Any])",
+      "delay(Long, TimeUnit)" -> "delay(Duration, Scheduler)",
+      "delaySubscription(Long, TimeUnit)" -> "delaySubscription(Duration, Scheduler)",
       "dematerialize()" -> "dematerialize(<:<[Observable[T], Observable[Notification[U]]])",
       "doOnCompleted(Action0)" -> "doOnCompleted(=> Unit)",
       "doOnEach(Action1[Notification[_ >: T]])" -> "[use `doOnEach(T => Unit, Throwable => Unit, () => Unit)`]",
@@ -104,6 +107,7 @@ class CompletenessTest extends JUnitSuite {
       "forEach(Action1[_ >: T], Action1[Throwable], Action0)" -> "foreach(T => Unit, Throwable => Unit, () => Unit)",
       "groupJoin(Observable[T2], Func1[_ >: T, _ <: Observable[D1]], Func1[_ >: T2, _ <: Observable[D2]], Func2[_ >: T, _ >: Observable[T2], _ <: R])" -> "groupJoin(Observable[S])(T => Observable[Any], S => Observable[Any], (T, Observable[S]) => R)",
       "ignoreElements()" -> "[use `filter(_ => false)`]",
+      "interval(Long, TimeUnit)" -> "interval(Duration, Scheduler)",
       "join(Observable[TRight], Func1[T, Observable[TLeftDuration]], Func1[TRight, Observable[TRightDuration]], Func2[T, TRight, R])" -> "join(Observable[S])(T => Observable[Any], S => Observable[Any], (T, S) => R)",
       "last(Func1[_ >: T, Boolean])" -> "[use `filter(predicate).last`]",
       "lastOrDefault(T)" -> "lastOrElse(=> U)",
@@ -126,11 +130,12 @@ class CompletenessTest extends JUnitSuite {
       "publishLast(Func1[_ >: Observable[T], _ <: Observable[R]])" -> "publishLast(Observable[T] => Observable[R])",
       "reduce(Func2[T, T, T])" -> "reduce((U, U) => U)",
       "reduce(R, Func2[R, _ >: T, R])" -> "foldLeft(R)((R, T) => R)",
-      "repeatWhen(Func1[_ >: Observable[_ <: Void], _ <: Observable[_]])" -> "repeatWhen(Observable[Unit] => Observable[Any])",
+      "repeat(Long)" -> "repeat(Long, Scheduler)",
+      "repeatWhen(Func1[_ >: Observable[_ <: Void], _ <: Observable[_]])" -> "repeatWhen(Observable[Unit] => Observable[Any], Scheduler)",
       "repeatWhen(Func1[_ >: Observable[_ <: Void], _ <: Observable[_]], Scheduler)" -> "repeatWhen(Observable[Unit] => Observable[Any], Scheduler)",
       "replay(Func1[_ >: Observable[T], _ <: Observable[R]])" -> "replay(Observable[T] => Observable[R])",
       "replay(Func1[_ >: Observable[T], _ <: Observable[R]], Int)" -> "replay(Observable[T] => Observable[R], Int)",
-      "replay(Func1[_ >: Observable[T], _ <: Observable[R]], Int, Long, TimeUnit)" -> "replay(Observable[T] => Observable[R], Int, Duration)",
+      "replay(Func1[_ >: Observable[T], _ <: Observable[R]], Int, Long, TimeUnit)" -> "replay(Observable[T] => Observable[R], Int, Duration, Scheduler)",
       "replay(Func1[_ >: Observable[T], _ <: Observable[R]], Int, Long, TimeUnit, Scheduler)" -> "replay(Observable[T] => Observable[R], Int, Duration, Scheduler)",
       "replay(Func1[_ >: Observable[T], _ <: Observable[R]], Int, Scheduler)" -> "replay(Observable[T] => Observable[R], Int, Scheduler)",
       "replay(Func1[_ >: Observable[T], _ <: Observable[R]], Long, TimeUnit)" -> "replay(Observable[T] => Observable[R], Duration)",
@@ -138,7 +143,8 @@ class CompletenessTest extends JUnitSuite {
       "replay(Func1[_ >: Observable[T], _ <: Observable[R]], Scheduler)" -> "replay(Observable[T] => Observable[R], Scheduler)",
       "retry(Func2[Integer, Throwable, Boolean])" -> "retry((Int, Throwable) => Boolean)",
       "retryWhen(Func1[_ >: Observable[_ <: Throwable], _ <: Observable[_]], Scheduler)" -> "retryWhen(Observable[Throwable] => Observable[Any], Scheduler)",
-      "retryWhen(Func1[_ >: Observable[_ <: Throwable], _ <: Observable[_]])" -> "retryWhen(Observable[Throwable] => Observable[Any])",
+      "retryWhen(Func1[_ >: Observable[_ <: Throwable], _ <: Observable[_]])" -> "retryWhen(Observable[Throwable] => Observable[Any], Scheduler)",
+      "sample(Long, TimeUnit)" -> "sample(Duration, Scheduler)",
       "sample(Observable[U])" -> "sample(Observable[Any])",
       "scan(Func2[T, T, T])" -> unnecessary,
       "scan(R, Func2[R, _ >: T, R])" -> "scan(R)((R, T) => R)",
@@ -146,7 +152,7 @@ class CompletenessTest extends JUnitSuite {
       "singleOrDefault(T)" -> "singleOrElse(=> U)",
       "singleOrDefault(T, Func1[_ >: T, Boolean])" -> "[use `filter(predicate).singleOrElse(default)`]",
       "skip(Int)" -> "drop(Int)",
-      "skip(Long, TimeUnit)" -> "drop(Duration)",
+      "skip(Long, TimeUnit)" -> "drop(Duration, Scheduler)",
       "skip(Long, TimeUnit, Scheduler)" -> "drop(Duration, Scheduler)",
       "skipWhile(Func1[_ >: T, Boolean])" -> "dropWhile(T => Boolean)",
       "skipWhileWithIndex(Func2[_ >: T, Integer, Boolean])" -> unnecessary,
@@ -155,12 +161,12 @@ class CompletenessTest extends JUnitSuite {
       "startWith(Iterable[T])" -> "[use `Observable.from(iterable) ++ o`]",
       "startWith(Observable[T])" -> "[use `++`]",
       "skipLast(Int)" -> "dropRight(Int)",
-      "skipLast(Long, TimeUnit)" -> "dropRight(Duration)",
+      "skipLast(Long, TimeUnit)" -> "dropRight(Duration, Scheduler)",
       "skipLast(Long, TimeUnit, Scheduler)" -> "dropRight(Duration, Scheduler)",
       "subscribe()" -> "subscribe()",
       "takeFirst(Func1[_ >: T, Boolean])" -> "[use `filter(condition).take(1)`]",
       "takeLast(Int)" -> "takeRight(Int)",
-      "takeLast(Long, TimeUnit)" -> "takeRight(Duration)",
+      "takeLast(Long, TimeUnit)" -> "takeRight(Duration, Scheduler)",
       "takeLast(Long, TimeUnit, Scheduler)" -> "takeRight(Duration, Scheduler)",
       "takeLast(Int, Long, TimeUnit)" -> "takeRight(Int, Duration)",
       "takeLast(Int, Long, TimeUnit, Scheduler)" -> "takeRight(Int, Duration, Scheduler)",
@@ -184,16 +190,21 @@ class CompletenessTest extends JUnitSuite {
       "toMultimap(Func1[_ >: T, _ <: K], Func1[_ >: T, _ <: V], Func0[_ <: Map[K, Collection[V]]], Func1[_ >: K, _ <: Collection[V]])" -> "toMultimap(T => K, T => V, () => M, K => B)",
       "toSortedList()" -> "[Sorting is already done in Scala's collection library, use `.toSeq.map(_.sorted)`]",
       "toSortedList(Func2[_ >: T, _ >: T, Integer])" -> "[Sorting is already done in Scala's collection library, use `.toSeq.map(_.sortWith(f))`]",
+      "throttleLast(Long, TimeUnit)" -> "throttleLast(Duration, Scheduler)",
+      "timeInterval()" -> "timeInterval(Scheduler)",
+      "timeout(Long, TimeUnit)" -> "timeout(Duration, Scheduler)",
+      "timer(Long, TimeUnit)" -> "timer(Duration, Scheduler)",
+      "timestamp()" -> "timestamp(Scheduler)",
       "window(Int)" -> "tumbling(Int)",
       "window(Int, Int)" -> "sliding(Int, Int)",
-      "window(Long, TimeUnit)" -> "tumbling(Duration)",
+      "window(Long, TimeUnit)" -> "tumbling(Duration, Scheduler)",
       "window(Long, TimeUnit, Int)" -> "tumbling(Duration, Int)",
       "window(Long, TimeUnit, Int, Scheduler)" -> "tumbling(Duration, Int, Scheduler)",
       "window(Long, TimeUnit, Scheduler)" -> "tumbling(Duration, Scheduler)",
       "window(Observable[U])" -> "tumbling(=> Observable[Any])",
       "window(Func0[_ <: Observable[_ <: TClosing]])" -> "tumbling(=> Observable[Any])",
       "window(Observable[_ <: TOpening], Func1[_ >: TOpening, _ <: Observable[_ <: TClosing]])" -> "sliding(Observable[Opening])(Opening => Observable[Any])",
-      "window(Long, Long, TimeUnit)" -> "sliding(Duration, Duration)",
+      "window(Long, Long, TimeUnit)" -> "sliding(Duration, Duration, Scheduler)",
       "window(Long, Long, TimeUnit, Scheduler)" -> "sliding(Duration, Duration, Scheduler)",
       "window(Long, Long, TimeUnit, Int, Scheduler)" -> "sliding(Duration, Duration, Int, Scheduler)",
 
@@ -372,7 +383,7 @@ class CompletenessTest extends JUnitSuite {
       println(s"Warning: $m is NOT present in $tp")
     }
 
-    printMethodPresenceStatus(good, bad, tp)
+    checkMethodPresenceStatus(good, bad, tp)
   }
 
   @Test def checkScalaMethodPresenceVerbose(): Unit = {
@@ -393,12 +404,15 @@ class CompletenessTest extends JUnitSuite {
       }
     }
     
-    printMethodPresenceStatus(good, bad, "Scala Observable")
+    checkMethodPresenceStatus(good, bad, "Scala Observable")
   }
 
-  def printMethodPresenceStatus(goodCount: Int, badCount: Int, instance: Any): Unit = {
-    val status = if (badCount == 0) "SUCCESS:" else "FAILURE: Only"
-    println(s"\n$status $goodCount out of ${badCount+goodCount} methods were found in $instance")
+  def checkMethodPresenceStatus(goodCount: Int, badCount: Int, instance: Any): Unit = {
+    if (badCount == 0) {
+      println(s"SUCCESS: $goodCount out of ${badCount+goodCount} methods were found in $instance")
+    } else {
+      fail(s"FAILURE: Only $goodCount out of ${badCount+goodCount} methods were found in $instance")
+    }
   }
 
   def setTodoForMissingMethods(corresp: Map[String, String]): Map[String, String] = {


### PR DESCRIPTION
- Changes some methods to require parentheses (timestamp, timeInterval)
- Make CompletenessTest fail unit tests

Fixes #40, #36
