### PR TITLE
Add an implicit toSerialized method

### DIFF
--- a/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala
+++ b/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala
@@ -1594,7 +1594,7 @@ class RxScalaDemo extends JUnitSuite {
   
   @Test def eventBusExample(): Unit = {
     val eventBus = Subject[String]()
-    val threadsafeEventBus = SerializedSubject[String](eventBus)
+    val threadsafeEventBus = eventBus.toSerialized
     
     val event1ProducerSubscription = Observable.interval(10.milliseconds)
       .map(i => s"Event 1 producer: $i")

--- a/src/main/scala/rx/lang/scala/Subject.scala
+++ b/src/main/scala/rx/lang/scala/Subject.scala
@@ -15,6 +15,8 @@
  */
 package rx.lang.scala
 
+import scala.language.implicitConversions
+
 /**
 * A Subject is an Observable and an Observer at the same time.
 */
@@ -55,4 +57,15 @@ object Subject {
    * @return the new `Subject`
    */
   def apply[T](): Subject[T] = new rx.lang.scala.subjects.PublishSubject[T](rx.subjects.PublishSubject.create())
+
+  implicit class SubjectExtensions[T](val subject: Subject[T]) extends AnyVal {
+
+    def toSerialized: rx.lang.scala.subjects.SerializedSubject[T] = {
+      subject match {
+        case s: rx.lang.scala.subjects.SerializedSubject[T] => s
+        case s => rx.lang.scala.subjects.SerializedSubject[T](s)
+      }
+    }
+
+  }
 }


### PR DESCRIPTION
An convenient implicit method for `SerializedSubject`.
