### PR TITLE
Refactor Subscriber to support backpressure when using lift and bug fixes

### DIFF
--- a/src/main/scala/rx/lang/scala/Subscriber.scala
+++ b/src/main/scala/rx/lang/scala/Subscriber.scala
@@ -105,14 +105,6 @@ object Subscriber extends ObserverFactoryMethods[Subscriber] {
     }
   }
 
-  def apply[T](subscriber: Subscriber[_], onNext: T => Unit, onError: Throwable => Unit, onCompleted: () => Unit): Subscriber[T] = {
-    val n = onNext; val e = onError; val c = onCompleted
-    new Subscriber[T](subscriber) {
-      override def onNext(value: T): Unit = n(value)
-      override def onError(error: Throwable): Unit = e(error)
-      override def onCompleted(): Unit = c()
-    }
-  }
 }
 
 private[scala] sealed trait SubscriberAdapter[T] extends rx.Subscriber[T] {

--- a/src/test/scala/rx/lang/scala/ObservableTest.scala
+++ b/src/test/scala/rx/lang/scala/ObservableTest.scala
@@ -383,4 +383,49 @@ class ObservableTests extends JUnitSuite {
     assertTrue(completed)
     assertFalse(error)
   }
+
+  @Test
+  def testToListWithBackpressure() {
+    var result: List[Int] = null
+    var completed = false
+    var error = false
+    Observable.just(1, 2).toList.subscribe(new Subscriber[List[Int]] {
+      override def onStart(): Unit = request(1)
+
+      override def onNext(v: List[Int]): Unit = {
+        result = v
+        request(1)
+      }
+
+      override def onError(e: Throwable): Unit = error = true
+
+      override def onCompleted(): Unit = completed = true
+    })
+    assertEquals(List(1, 2), result)
+    assertTrue(completed)
+    assertFalse(error)
+  }
+
+  @Test
+  def testToMultimapWithBackpressure() {
+    var result: scala.collection.Map[Int, scala.collection.Seq[Int]] = null
+    var completed = false
+    var error = false
+    Observable.just(1, 2, 3, 4).toMultimap(_ % 2).subscribe(new Subscriber[scala.collection.Map[Int, scala.collection.Seq[Int]]] {
+      override def onStart(): Unit = request(1)
+
+      override def onNext(v: scala.collection.Map[Int, scala.collection.Seq[Int]]): Unit = {
+        result = v
+        request(1)
+      }
+
+      override def onError(e: Throwable): Unit = error = true
+
+      override def onCompleted(): Unit = completed = true
+    })
+    assertEquals(Map((1, Seq(1, 3)), (0, Seq(2, 4))), result)
+    assertTrue(completed)
+    assertFalse(error)
+  }
+
 }


### PR DESCRIPTION
I found `tail` and `toXXX` didn't work after adding backpressure. To solve it, I have to change `Subscriber` to `abstract class` so that `Subscriber`s can be chained and call `request` properly.
