### PR TITLE
Refactor toMap

### DIFF
--- a/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala
+++ b/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala
@@ -993,15 +993,6 @@ class RxScalaDemo extends JUnitSuite {
     println(m.toBlocking.single)
   }
 
-  @Test def toMapExample3(): Unit = {
-    val o : Observable[String] = List("alice", "bob", "carol").toObservable
-    val keySelector = (s: String) => s.head
-    val valueSelector = (s: String) => s.tail
-    val mapFactory = () => Map(('s',"tart"))
-    val m = o.toMap(keySelector, valueSelector, mapFactory)
-    println(m.toBlocking.single)
-  }
-
   @Test def toMultimapExample1(): Unit = {
     val o : Observable[String] = List("alice", "bob", "carol", "allen", "clarke").toObservable
     val keySelector = (s: String) => s.head

--- a/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala
+++ b/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala
@@ -998,15 +998,7 @@ class RxScalaDemo extends JUnitSuite {
     val o : Observable[String] = List("alice", "bob", "carol").toObservable
     val keySelector = (s: String) => s.head
     val valueSelector = (s: String) => s.tail
-    val m: Observable[HashMap[Char, String]] = o.to(keySelector, valueSelector)
-    println(m.toBlocking.single)
-  }
-
-  @Test def toMapExample4(): Unit = {
-    val o : Observable[String] = List("alice", "bob", "carol").toObservable
-    val keySelector = (s: String) => s.head
-    val valueSelector = (s: String) => s.tail
-    val m = o.to[Char, String, HashMap](keySelector, valueSelector)
+    val m: Observable[HashMap[Char, String]] = o.to[HashMap, Char, String](keySelector, valueSelector)
     println(m.toBlocking.single)
   }
 

--- a/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala
+++ b/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit
 import rx.lang.scala.subjects.SerializedSubject
 
 import scala.concurrent.Await
+import scala.collection.immutable.HashMap
 import scala.collection.mutable
 import scala.concurrent.duration.Duration
 import scala.concurrent.duration.DurationInt
@@ -990,6 +991,22 @@ class RxScalaDemo extends JUnitSuite {
     val keySelector = (s: String) => s.head
     val valueSelector = (s: String) => s.tail
     val m = o.toMap(keySelector, valueSelector)
+    println(m.toBlocking.single)
+  }
+
+  @Test def toMapExample3(): Unit = {
+    val o : Observable[String] = List("alice", "bob", "carol").toObservable
+    val keySelector = (s: String) => s.head
+    val valueSelector = (s: String) => s.tail
+    val m: Observable[HashMap[Char, String]] = o.to(keySelector, valueSelector)
+    println(m.toBlocking.single)
+  }
+
+  @Test def toMapExample4(): Unit = {
+    val o : Observable[String] = List("alice", "bob", "carol").toObservable
+    val keySelector = (s: String) => s.head
+    val valueSelector = (s: String) => s.tail
+    val m = o.to[Char, String, HashMap](keySelector, valueSelector)
     println(m.toBlocking.single)
   }
 

--- a/src/main/scala/rx/lang/scala/Observable.scala
+++ b/src/main/scala/rx/lang/scala/Observable.scala
@@ -3776,15 +3776,15 @@ trait Observable[+T]
   }
 
   /**
-   * Return an Observable that emits a single `immutable.Map` containing all items emitted by the source Observable,
+   * Return an Observable that emits a single `Map` containing all items emitted by the source Observable,
    * mapped by the keys returned by a specified `keySelector` function.
    * <p>
    * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toMap.png">
    * <p>
-   * If more than one source item maps to the same key, the `immutable.Map` will contain the latest of those items.
+   * If more than one source item maps to the same key, the `Map` will contain the latest of those items.
    *
-   * @param keySelector the function that extracts the key from a source item to be used in the `immutable.Map`
-   * @return an Observable that emits a single item: an `immutable.Map` containing the mapped items from the source
+   * @param keySelector the function that extracts the key from a source item to be used in the `Map`
+   * @return an Observable that emits a single item: an `Map` containing the mapped items from the source
    *         Observable
    */
   def toMap[K](keySelector: T => K): Observable[Map[K, T]] = {
@@ -3792,17 +3792,17 @@ trait Observable[+T]
   }
 
   /**
-   * Return an Observable that emits a single `immutable.Map` containing values corresponding to items emitted by the
+   * Return an Observable that emits a single `Map` containing values corresponding to items emitted by the
    * source Observable, mapped by the keys returned by a specified `keySelector` function.
    * <p>
    * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toMap.png">
    * <p>
-   * If more than one source item maps to the same key, the `immutable.Map` will contain a single entry that
+   * If more than one source item maps to the same key, the `Map` will contain a single entry that
    * corresponds to the latest of those items.
    *
-   * @param keySelector the function that extracts the key from a source item to be used in the `immutable.Map`
-   * @param valueSelector the function that extracts the value from a source item to be used in the `immutable.Map`
-   * @return an Observable that emits a single item: an `immutable.Map` containing the mapped items from the source
+   * @param keySelector the function that extracts the key from a source item to be used in the `Map`
+   * @param valueSelector the function that extracts the value from a source item to be used in the `Map`
+   * @return an Observable that emits a single item: an `Map` containing the mapped items from the source
    *         Observable
    */
   def toMap[K, V](keySelector: T => K, valueSelector: T => V): Observable[Map[K, V]] = {
@@ -3844,16 +3844,16 @@ trait Observable[+T]
   }
 
   /**
-   * Return an Observable that emits a single `immutable.TreeMap` containing all items emitted by the source Observable,
+   * Return an Observable that emits a single `TreeMap` containing all items emitted by the source Observable,
    * mapped by the keys returned by a specified `keySelector` function.
    * <p>
    * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toMap.png">
    * <p>
-   * If more than one source item maps to the same key, the `immutable.TreeMap` will contain the latest of those items.
+   * If more than one source item maps to the same key, the `TreeMap` will contain the latest of those items.
    *
-   * @param keySelector the function that extracts the key from a source item to be used in the `immutable.TreeMap`
+   * @param keySelector the function that extracts the key from a source item to be used in the `TreeMap`
    * @param ord the implicit ordering used to compare the keys.
-   * @return an Observable that emits a single item: an `immutable.TreeMap` containing the mapped items from the source
+   * @return an Observable that emits a single item: an `TreeMap` containing the mapped items from the source
    *         Observable
    */
   def toTreeMap[K](keySelector: T => K)(implicit ord: Ordering[K]): Observable[immutable.TreeMap[K, T]] = {
@@ -3861,18 +3861,18 @@ trait Observable[+T]
   }
 
   /**
-   * Return an Observable that emits a single `immutable.TreeMap` containing values corresponding to items emitted by the
+   * Return an Observable that emits a single `TreeMap` containing values corresponding to items emitted by the
    * source Observable, mapped by the keys returned by a specified `keySelector` function.
    * <p>
    * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toMap.png">
    * <p>
-   * If more than one source item maps to the same key, the `immutable.TreeMap` will contain a single entry that
+   * If more than one source item maps to the same key, the `TreeMap` will contain a single entry that
    * corresponds to the latest of those items.
    *
-   * @param keySelector the function that extracts the key from a source item to be used in the `immutable.TreeMap`
-   * @param valueSelector the function that extracts the value from a source item to be used in the `immutable.TreeMap`
+   * @param keySelector the function that extracts the key from a source item to be used in the `TreeMap`
+   * @param valueSelector the function that extracts the value from a source item to be used in the `TreeMap`
    * @param ord the implicit ordering used to compare the keys.
-   * @return an Observable that emits a single item: an `immutable.TreeMap` containing the mapped items from the source
+   * @return an Observable that emits a single item: an `TreeMap` containing the mapped items from the source
    *         Observable
    */
   def toTreeMap[K, V](keySelector: T => K, valueSelector: T => V)(implicit ord: Ordering[K]): Observable[immutable.TreeMap[K, V]] = {

--- a/src/main/scala/rx/lang/scala/Observable.scala
+++ b/src/main/scala/rx/lang/scala/Observable.scala
@@ -3748,7 +3748,7 @@ trait Observable[+T]
    * @return an Observable that emits a single item: a `Map` containing the mapped items from the source
    *         Observable
    */
-  def to[K, V, M[_, _]](keySelector: T => K, valueSelector: T => V)(implicit cbf: CanBuildFrom[Nothing, (K, V), M[K, V]]): Observable[M[K, V]] = {
+  def to[M[_, _], K, V](keySelector: T => K, valueSelector: T => V)(implicit cbf: CanBuildFrom[Nothing, (K, V), M[K, V]]): Observable[M[K, V]] = {
     lift {
       (subscriber: Subscriber[M[K, V]]) => {
         new Subscriber[T](subscriber) {
@@ -3801,7 +3801,7 @@ trait Observable[+T]
    *         Observable
    */
   def toMap[K](keySelector: T => K): Observable[Map[K, T]] = {
-    to[K, T, Map](keySelector, v => v)
+    to[Map, K, T](keySelector, v => v)
   }
 
   /**
@@ -3819,77 +3819,7 @@ trait Observable[+T]
    *         Observable
    */
   def toMap[K, V](keySelector: T => K, valueSelector: T => V): Observable[Map[K, V]] = {
-    to[K, V, Map](keySelector, valueSelector)
-  }
-
-  /**
-   * Return an Observable that emits a single `mutable.Map` containing all items emitted by the source Observable,
-   * mapped by the keys returned by a specified `keySelector` function.
-   * <p>
-   * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toMap.png">
-   * <p>
-   * If more than one source item maps to the same key, the `mutable.Map` will contain the latest of those items.
-   *
-   * @param keySelector the function that extracts the key from a source item to be used in the `mutable.Map`
-   * @return an Observable that emits a single item: a `mutable.Map` containing the mapped items from the source
-   *         Observable
-   */
-  def toMutableMap[K, V >: T](keySelector: T => K): Observable[mutable.Map[K, V]] = {
-    to[K, V, mutable.Map](keySelector, v => v)
-  }
-
-  /**
-   * Return an Observable that emits a single `mutable.Map` containing values corresponding to items emitted by the
-   * source Observable, mapped by the keys returned by a specified `keySelector` function.
-   * <p>
-   * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toMap.png">
-   * <p>
-   * If more than one source item maps to the same key, the `mutable.Map` will contain a single entry that
-   * corresponds to the latest of those items.
-   *
-   * @param keySelector the function that extracts the key from a source item to be used in the `mutable.Map`
-   * @param valueSelector the function that extracts the value from a source item to be used in the `mutable.Map`
-   * @return an Observable that emits a single item: a `mutable.Map` containing the mapped items from the source
-   *         Observable
-   */
-  def toMutableMap[K, V](keySelector: T => K, valueSelector: T => V): Observable[mutable.Map[K, V]] = {
-    to[K, V, mutable.Map](keySelector, valueSelector)
-  }
-
-  /**
-   * Return an Observable that emits a single `TreeMap` containing all items emitted by the source Observable,
-   * mapped by the keys returned by a specified `keySelector` function.
-   * <p>
-   * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toMap.png">
-   * <p>
-   * If more than one source item maps to the same key, the `TreeMap` will contain the latest of those items.
-   *
-   * @param keySelector the function that extracts the key from a source item to be used in the `TreeMap`
-   * @param ord the implicit ordering used to compare the keys.
-   * @return an Observable that emits a single item: an `TreeMap` containing the mapped items from the source
-   *         Observable
-   */
-  def toTreeMap[K](keySelector: T => K)(implicit ord: Ordering[K]): Observable[immutable.TreeMap[K, T]] = {
-    to[K, T, immutable.TreeMap](keySelector, v => v)
-  }
-
-  /**
-   * Return an Observable that emits a single `TreeMap` containing values corresponding to items emitted by the
-   * source Observable, mapped by the keys returned by a specified `keySelector` function.
-   * <p>
-   * <img width="640" src="https://raw.github.com/wiki/Netflix/RxJava/images/rx-operators/toMap.png">
-   * <p>
-   * If more than one source item maps to the same key, the `TreeMap` will contain a single entry that
-   * corresponds to the latest of those items.
-   *
-   * @param keySelector the function that extracts the key from a source item to be used in the `TreeMap`
-   * @param valueSelector the function that extracts the value from a source item to be used in the `TreeMap`
-   * @param ord the implicit ordering used to compare the keys.
-   * @return an Observable that emits a single item: an `TreeMap` containing the mapped items from the source
-   *         Observable
-   */
-  def toTreeMap[K, V](keySelector: T => K, valueSelector: T => V)(implicit ord: Ordering[K]): Observable[immutable.TreeMap[K, V]] = {
-    to[K, V, immutable.TreeMap](keySelector, valueSelector)
+    to[Map, K, V](keySelector, valueSelector)
   }
 
   /**

--- a/src/main/scala/rx/lang/scala/Observable.scala
+++ b/src/main/scala/rx/lang/scala/Observable.scala
@@ -3776,6 +3776,19 @@ trait Observable[+T]
   }
 
   /**
+   * Return an Observable that emits a single `Map` containing all pairs emitted by the source Observable.
+   * This method is unavailable unless the elements are members of `(K, V)`. Each `(K, V)` becomes a key-value
+   * pair in the map. If more than one pairs have the same key, the `Map` will contain the latest of
+   * those items.
+   *
+   * @return an Observable that emits a single item: an `Map` containing all pairs from the source Observable
+   */
+  def toMap[K, V](implicit ev: Observable[T] <:< Observable[(K, V)]): Observable[Map[K, V]] = {
+    val o: Observable[(K, V)] = this
+    o.toMap(_._1, _._2)
+  }
+
+  /**
    * Return an Observable that emits a single `Map` containing all items emitted by the source Observable,
    * mapped by the keys returned by a specified `keySelector` function.
    * <p>

--- a/src/test/scala/rx/lang/scala/CompletenessTest.scala
+++ b/src/test/scala/rx/lang/scala/CompletenessTest.scala
@@ -175,6 +175,7 @@ class CompletenessTest extends JUnitSuite {
       "timer(Long, Long, TimeUnit)" -> "timer(Duration, Duration)",
       "timer(Long, Long, TimeUnit, Scheduler)" -> "timer(Duration, Duration, Scheduler)",
       "toList()" -> "toSeq",
+      "toMap(Func1[_ >: T, _ <: K], Func1[_ >: T, _ <: V], Func0[_ <: Map[K, V]])" -> "[mapFactory is not necessary because Scala has `CanBuildFrom`]",
       "toMultimap(Func1[_ >: T, _ <: K], Func1[_ >: T, _ <: V], Func0[_ <: Map[K, Collection[V]]])" -> "toMultimap(T => K, T => V, () => M)",
       "toMultimap(Func1[_ >: T, _ <: K], Func1[_ >: T, _ <: V], Func0[_ <: Map[K, Collection[V]]], Func1[_ >: K, _ <: Collection[V]])" -> "toMultimap(T => K, T => V, () => M, K => B)",
       "toSortedList()" -> "[Sorting is already done in Scala's collection library, use `.toSeq.map(_.sorted)`]",

--- a/src/test/scala/rx/lang/scala/ObservableTest.scala
+++ b/src/test/scala/rx/lang/scala/ObservableTest.scala
@@ -437,6 +437,10 @@ class ObservableTests extends JUnitSuite {
     val expectedMap2 = (0 to 100).map(i => (i % 2, i * 100)).toMap
     val m2 = (0 to 100).toObservable.toMap(_ % 2, _ * 100)
     assertEquals(expectedMap2, m2.toBlocking.single)
+
+    val expectedMap3 = (0 to 100).map(i => (i % 2, i * 100)).toMap
+    val m3 = (0 to 100).toObservable.map(i => (i % 2, i * 100)).toMap
+    assertEquals(expectedMap3, m3.toBlocking.single)
   }
 
   @Test

--- a/src/test/scala/rx/lang/scala/ObservableTest.scala
+++ b/src/test/scala/rx/lang/scala/ObservableTest.scala
@@ -443,25 +443,4 @@ class ObservableTests extends JUnitSuite {
     assertEquals(expectedMap3, m3.toBlocking.single)
   }
 
-  @Test
-  def testToMutableMap() {
-    val expectedMap1 = (0 to 100).map(i => (i % 2, i)).toMap
-    val m1 = (0 to 100).toObservable.toMutableMap(_ % 2)
-    assertEquals(expectedMap1, m1.toBlocking.single)
-
-    val expectedMap2 = (0 to 100).map(i => (i % 2, i * 100)).toMap
-    val m2 = (0 to 100).toObservable.toMutableMap(_ % 2, _ * 100)
-    assertEquals(expectedMap2, m2.toBlocking.single)
-  }
-
-  @Test
-  def testToTreeMap() {
-    val expectedMap1 = (0 to 100).map(i => (i % 2, i)).toMap
-    val m1 = (0 to 100).toObservable.toTreeMap(_ % 2)
-    assertEquals(expectedMap1, m1.toBlocking.single)
-
-    val expectedMap2 = (0 to 100).map(i => (i % 2, i * 100)).toMap
-    val m2 = (0 to 100).toObservable.toTreeMap(_ % 2, _ * 100)
-    assertEquals(expectedMap2, m2.toBlocking.single)
-  }
 }

--- a/src/test/scala/rx/lang/scala/ObservableTest.scala
+++ b/src/test/scala/rx/lang/scala/ObservableTest.scala
@@ -428,4 +428,36 @@ class ObservableTests extends JUnitSuite {
     assertFalse(error)
   }
 
+  @Test
+  def testToMap() {
+    val expectedMap1 = (0 to 100).map(i => (i % 2, i)).toMap
+    val m1 = (0 to 100).toObservable.toMap(_ % 2)
+    assertEquals(expectedMap1, m1.toBlocking.single)
+
+    val expectedMap2 = (0 to 100).map(i => (i % 2, i * 100)).toMap
+    val m2 = (0 to 100).toObservable.toMap(_ % 2, _ * 100)
+    assertEquals(expectedMap2, m2.toBlocking.single)
+  }
+
+  @Test
+  def testToMutableMap() {
+    val expectedMap1 = (0 to 100).map(i => (i % 2, i)).toMap
+    val m1 = (0 to 100).toObservable.toMutableMap(_ % 2)
+    assertEquals(expectedMap1, m1.toBlocking.single)
+
+    val expectedMap2 = (0 to 100).map(i => (i % 2, i * 100)).toMap
+    val m2 = (0 to 100).toObservable.toMutableMap(_ % 2, _ * 100)
+    assertEquals(expectedMap2, m2.toBlocking.single)
+  }
+
+  @Test
+  def testToTreeMap() {
+    val expectedMap1 = (0 to 100).map(i => (i % 2, i)).toMap
+    val m1 = (0 to 100).toObservable.toTreeMap(_ % 2)
+    assertEquals(expectedMap1, m1.toBlocking.single)
+
+    val expectedMap2 = (0 to 100).map(i => (i % 2, i * 100)).toMap
+    val m2 = (0 to 100).toObservable.toTreeMap(_ % 2, _ * 100)
+    assertEquals(expectedMap2, m2.toBlocking.single)
+  }
 }


### PR DESCRIPTION
A PR to refactor `toMap`.

There is a breaking change in this PR: 
- Remove `def toMap[K, V] (keySelector: T => K, valueSelector: T => V, mapFactory: () => Map[K, V]): Observable[Map[K, V]]`

The other changes are still source compatible and binary compatible.
