### PR TITLE
Fix onErrorResumeNext partial function ambiguity problem

### DIFF
--- a/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala
+++ b/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala
@@ -1480,6 +1480,21 @@ class RxScalaDemo extends JUnitSuite {
     o.onErrorResumeNext(_ => Observable.just(10, 11, 12)).subscribe(println(_))
   }
 
+  @Test def onErrorResumeNextExamplePartialFunction() {
+    val o = Observable {
+      (subscriber: Subscriber[Int]) =>
+        subscriber.onNext(1)
+        subscriber.onNext(2)
+        subscriber.onError(new IOException("Oops"))
+        subscriber.onNext(3)
+        subscriber.onNext(4)
+    }
+    o.onErrorResumeNext({
+      case e: IOException => Observable.just(20, 21, 22)
+      case _ => Observable.just(10, 11, 12)
+    }).subscribe(println(_))
+  }
+
   @Test def switchMapExample() {
     val o = Observable.interval(300 millis).take(5).switchMap[String] {
       n => Observable.interval(50 millis).take(10).map(i => s"Seq ${n}: ${i}")

--- a/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala
+++ b/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala
@@ -1474,25 +1474,21 @@ class RxScalaDemo extends JUnitSuite {
         subscriber.onNext(1)
         subscriber.onNext(2)
         subscriber.onError(new IOException("Oops"))
-        subscriber.onNext(3)
-        subscriber.onNext(4)
     }
     o.onErrorResumeNext(_ => Observable.just(10, 11, 12)).subscribe(println(_))
   }
 
-  @Test def onErrorResumeNextExamplePartialFunction() {
+  @Test def onErrorResumeNextCaseExample() {
     val o = Observable {
       (subscriber: Subscriber[Int]) =>
         subscriber.onNext(1)
         subscriber.onNext(2)
         subscriber.onError(new IOException("Oops"))
-        subscriber.onNext(3)
-        subscriber.onNext(4)
     }
-    o.onErrorResumeNext({
+    o.onErrorResumeNext {
       case e: IOException => Observable.just(20, 21, 22)
       case _ => Observable.just(10, 11, 12)
-    }).subscribe(println(_))
+    }.subscribe(println(_))
   }
 
   @Test def switchMapExample() {

--- a/src/main/scala/rx/lang/scala/Observable.scala
+++ b/src/main/scala/rx/lang/scala/Observable.scala
@@ -1131,37 +1131,6 @@ trait Observable[+T]
   }
 
   /**
-   * Instruct an Observable to pass control to another Observable rather than invoking [[rx.lang.scala.Observer.onError onError]] if it encounters an error.
-   *
-   * <img width="640" height="310" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/onErrorResumeNext.png" alt="" />
-   *
-   * By default, when an Observable encounters an error that prevents it from emitting the
-   * expected item to its [[rx.lang.scala.Observer]], the Observable invokes its Observer's
-   * `onError` method, and then quits without invoking any more of its Observer's
-   * methods. The `onErrorResumeNext` method changes this behavior. If you pass
-   * another Observable (`resumeSequence`) to an Observable's
-   * `onErrorResumeNext` method, if the original Observable encounters an error,
-   * instead of invoking its Observer's `onError` method, it will instead relinquish
-   * control to `resumeSequence` which will invoke the Observer's [[rx.lang.scala.Observer.onNext onNext]]
-   * method if it is able to do so. In such a case, because no
-   * Observable necessarily invokes `onError`, the Observer may never know that an
-   * error happened.
-   *
-   * You can use this to prevent errors from propagating or to supply fallback data should errors
-   * be encountered.
-   *
-   * @param resumeSequence
-   *            a function that returns an Observable that will take over if the source Observable
-   *            encounters an error
-   * @return the original Observable, with appropriately modified behavior
-   */
-  def onErrorResumeNext[U >: T](resumeSequence: Observable[U]): Observable[U] = {
-    val rSeq1: rx.Observable[_ <: U] = resumeSequence.asJavaObservable
-    val rSeq2: rx.Observable[Nothing] = rSeq1.asInstanceOf[rx.Observable[Nothing]]
-    toScalaObservable[U](asJavaObservable.onErrorResumeNext(rSeq2))
-  }
-
-  /**
    * Instruct an Observable to pass control to another Observable rather than invoking [[rx.lang.scala.Observer.onError onError]] if it encounters an error of type `java.lang.Exception`.
    *
    * This differs from `Observable.onErrorResumeNext` in that this one does not handle `java.lang.Throwable` or `java.lang.Error` but lets those continue through.

--- a/src/test/scala/rx/lang/scala/CompletenessTest.scala
+++ b/src/test/scala/rx/lang/scala/CompletenessTest.scala
@@ -134,7 +134,7 @@ class CompletenessTest extends JUnitSuite {
       "mergeWith(Observable[_ <: T])" -> "merge(Observable[U])",
       "ofType(Class[R])" -> "[use `filter(_.isInstanceOf[Class])`]",
       "onErrorResumeNext(Func1[Throwable, _ <: Observable[_ <: T]])" -> "onErrorResumeNext(Throwable => Observable[U])",
-      "onErrorResumeNext(Observable[_ <: T])" -> "onErrorResumeNext(Observable[U])",
+      "onErrorResumeNext(Observable[_ <: T])" -> "onErrorResumeNext(Throwable => Observable[U])",
       "onErrorReturn(Func1[Throwable, _ <: T])" -> "onErrorReturn(Throwable => U)",
       "onExceptionResumeNext(Observable[_ <: T])" -> "onExceptionResumeNext(Observable[U])",
       "publish(Func1[_ >: Observable[T], _ <: Observable[R]])" -> "publish(Observable[T] => Observable[R])",


### PR DESCRIPTION
As described in #79, the current implementation of having two overloaded onErrorResumeNext methods leads to ambiguity problems with the common Scala partial function shorthand idiom. This pull request solves this by removing one of the onErrorResumeNext methods, since the functionality of that method can be accomplished by using the remaining method.
