### PR TITLE
Optimize the 'error' signature

### DIFF
--- a/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala
+++ b/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala
@@ -1644,4 +1644,10 @@ class RxScalaDemo extends JUnitSuite {
     event1ProducerSubscription.unsubscribe()
     event2ProducerSubscription.unsubscribe()
   }
+
+  @Test def errorExample(): Unit = {
+    val o1 = Observable.just(1, 2, 3)
+    val o2 = Observable.error(new RuntimeException("Oops"))
+    (o1 ++ o2).subscribe(v => println(v), e => e.printStackTrace(), () => println("completed"))
+  }
 }

--- a/src/main/scala/rx/lang/scala/Observable.scala
+++ b/src/main/scala/rx/lang/scala/Observable.scala
@@ -4394,20 +4394,18 @@ object Observable {
   }
   
   /**
-   * Returns an Observable that invokes an [[rx.lang.scala.Observer]]'s [[rx.lang.scala.Observer.onError onError]]
-   * method when the Observer subscribes to it.
+   * Returns an [[Observable]] that invokes the [[Observer.onError]] method when the [[Observer]] subscribes to it.
    *
    * <img width="640" height="190" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/error.png" alt="" />
    *
-   * @param exception
-   *            the particular error to report
-   * @tparam T
-   *            the type of the items (ostensibly) emitted by the Observable
-   * @return an Observable that invokes the [[rx.lang.scala.Observer]]'s [[rx.lang.scala.Observer.onError onError]]
-   *         method when the Observer subscribes to it
+   * ===Scheduler:===
+   * `error` does not operate by default on a particular [[Scheduler]].
+   *
+   * @param exception the particular `Throwable` to pass to [[Observer.onError]]
+   * @return an [[Observable]] that invokes the [[Observer.onError]] method when the [[Observer]] subscribes to it
    */
-  def error[T](exception: Throwable): Observable[T] = {
-    toScalaObservable[T](rx.Observable.error(exception))
+  def error(exception: Throwable): Observable[Nothing] = {
+    toScalaObservable(rx.Observable.error(exception))
   }
 
   /**

--- a/src/test/scala/rx/lang/scala/ObservableTest.scala
+++ b/src/test/scala/rx/lang/scala/ObservableTest.scala
@@ -94,7 +94,7 @@ class ObservableTests extends JUnitSuite {
     val msg = "msg6251"
     var receivedMsg = "none"
     try {
-      Observable.error[Int](new Exception(msg)).firstOrElse(10).toBlocking.single
+      Observable.error(new Exception(msg)).firstOrElse(10).toBlocking.single
     } catch {
       case e: Exception => receivedMsg = e.getCause().getMessage()
     }
@@ -428,4 +428,15 @@ class ObservableTests extends JUnitSuite {
     assertEquals(expectedMap3, m3.toBlocking.single)
   }
 
+  @Ignore // Don't run it. Only test if it can be compiled
+  def testErrorSignature() {
+    val o: Observable[Int] = Observable.error(new RuntimeException("Oops")).map(v => v)
+    println(o.toBlocking.single)
+
+    val x = 1
+    println(x + (Observable.error(new RuntimeException("Oops")).toBlocking.single: Int))
+
+    val y: Int = Observable.error(new RuntimeException("Oops")).toBlocking.single
+    println(y)
+  }
 }


### PR DESCRIPTION
As per #80

This will break the source compatibility. E.g., `Observable.error[Int](new Exception(msg)).firstOrElse(10).toBlocking.single` won't be compiled.

Hold off until we prepare to release 0.24.0.
