### PR TITLE
Add ExperimentalObservable

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ Since RxScala is part of the RxJava family the communication channels are simila
 [1] You can use any release of RxScala 0.23 with any release of RxJava 1.0. E.g, use RxScala 0.23.0 with RxJava 1.0.1 <br/>
 [2] You should use the same version of RxScala with RxJava. E.g, use RxScala 0.20.1 with RxJava 0.20.1
 
+From 0.23.2, RxScala adds ExperimentalAPIs, which contains APIs using RxJava Beta/Experimental APIs. As these APIs are unstable in RxJava,
+if you `import ExperimentalAPIs`, you should use the corresponding version of RxJava as the following table:
+
+| RxScala version | Compatible RxJava version |
+| ------------------- | ------------------------- |
+| 0.23.2 | 1.0.7 |
+
 ## Full Documentation
 
 RxScala: 

--- a/examples/src/test/scala/rx/lang/scala/examples/ExperimentalAPIExamples.scala
+++ b/examples/src/test/scala/rx/lang/scala/examples/ExperimentalAPIExamples.scala
@@ -1,0 +1,146 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.lang.scala.examples
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+import org.junit.Ignore
+import org.junit.Test
+
+import rx.lang.scala._
+import rx.lang.scala.schedulers._
+import rx.lang.scala.ExperimentalAPIs._
+
+@Ignore
+object ExperimentalAPIExamples {
+
+  @Test def noBackpressureExample(): Unit = {
+    Observable[Int](subscriber => {
+      (1 to 200).foreach(subscriber.onNext)
+    }).observeOn(IOScheduler()).subscribe(
+      v => {
+        Thread.sleep(10) // A slow consumer
+        println(s"process $v")
+      },
+      e => e.printStackTrace()
+    )
+  }
+
+  @Test def onBackpressureBlockExample(): Unit = {
+    Observable[Int](subscriber => {
+      (1 to 200).foreach(subscriber.onNext)
+    }).doOnNext(v => println(s"emit $v")).onBackpressureBlock.observeOn(IOScheduler()).subscribe {
+      v =>
+        Thread.sleep(10) // A slow consumer
+        println(s"process $v")
+    }
+  }
+
+  @Test def onBackpressureBlockExample2(): Unit = {
+    Observable[Int](subscriber => {
+      (1 to 200).foreach(subscriber.onNext)
+    }).doOnNext(v => println(s"emit $v")).onBackpressureBlock(10).observeOn(IOScheduler()).subscribe {
+      v =>
+        Thread.sleep(10) // A slow consumer
+        println(s"process $v")
+    }
+  }
+
+  @Test def doOnRequestExample(): Unit = {
+    (1 to 300).toObservable.doOnRequest(request => println(s"request $request")).subscribe(new Subscriber[Int]() {
+      override def onStart(): Unit = request(1)
+
+      override def onNext(v: Int): Unit = request(1)
+
+      override def onError(e: Throwable): Unit = e.printStackTrace()
+
+      override def onCompleted(): Unit = {}
+    })
+  }
+
+  @Test def onBackpressureBufferWithCapacityExample(): Unit = {
+    Observable[Int](subscriber => {
+      (1 to 200).foreach(subscriber.onNext)
+    }).onBackpressureBufferWithCapacity(200).observeOn(IOScheduler()).subscribe {
+      v =>
+        Thread.sleep(10) // A slow consumer
+        println(s"process $v")
+    }
+  }
+
+  @Test def onBackpressureBufferWithCapacityExample2(): Unit = {
+    Observable[Int](subscriber => {
+      (1 to 200).foreach(subscriber.onNext)
+    }).onBackpressureBufferWithCapacity(10, println("Overflow")).observeOn(IOScheduler()).subscribe(
+      v => {
+        Thread.sleep(10)
+        // A slow consumer
+        println(s"process $v")
+      },
+      e => e.printStackTrace()
+    )
+  }
+
+  @Test def switchIfEmptyExample(): Unit = {
+    val o1: Observable[Int] = Observable.empty
+    val o2 = Observable.just(1, 3, 5)
+    val alternate = Observable.just(2, 4, 6)
+    o1.switchIfEmpty(alternate).foreach(println)
+    o2.switchIfEmpty(alternate).foreach(println)
+  }
+
+  @Test def withLatestFromExample(): Unit = {
+    val a = Observable.interval(1 second).take(7)
+    val b = Observable.interval(250 millis)
+    a.withLatestFrom(b)((x, y) => (x, y)).toBlocking.foreach {
+      case (x, y) => println(s"a: $x b: $y")
+    }
+  }
+
+  @Test def withLatestFromExample2(): Unit = {
+    val a = Observable.interval(1 second).take(7)
+    val b = Observable.timer(3 seconds, 250 millis)
+    a.withLatestFrom(b)((x, y) => (x, y)).toBlocking.foreach {
+      case (x, y) => println(s"a: $x b: $y")
+    }
+  }
+
+  @Test def takeUntilExample(): Unit = {
+    Observable.just(1, 2, 3, 4, 5, 6, 7).
+      doOnNext(v => println(s"onNext: $v")).
+      takeUntil((x: Int) => x == 3). // why the compiler cannot infer `int`?
+      foreach(println)
+  }
+
+  @Test def flatMapWithMaxConcurrentExample(): Unit = {
+    (1 to 1000000).toObservable
+      .doOnNext(v => println(s"Emitted Value: $v"))
+      .flatMapWithMaxConcurrent((v: Int) => Observable.just(v).doOnNext(_ => Thread.sleep(1)).subscribeOn(IOScheduler()), 10)
+      .toBlocking.foreach(v => System.out.println("Received: " + v))
+  }
+
+  @Test def flatMapWithMaxConcurrentExample2(): Unit = {
+    (1 to 1000000).toObservable
+      .doOnNext(v => println(s"Emitted Value: $v"))
+      .flatMapWithMaxConcurrent(
+        (v: Int) => Observable.just(v).doOnNext(_ => Thread.sleep(1)).subscribeOn(IOScheduler()),
+        e => Observable.just(-1).doOnNext(_ => Thread.sleep(1)).subscribeOn(IOScheduler()),
+        () => Observable.just(Int.MaxValue).doOnNext(_ => Thread.sleep(1)).subscribeOn(IOScheduler()),
+        10)
+      .toBlocking.foreach(v => System.out.println("Received: " + v))
+  }
+}

--- a/src/main/scala/rx/lang/scala/ExperimentalAPIs.scala
+++ b/src/main/scala/rx/lang/scala/ExperimentalAPIs.scala
@@ -1,0 +1,248 @@
+/**
+ * Copyright 2014 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package rx.lang.scala
+
+import scala.language.implicitConversions
+import rx.functions._
+import JavaConversions._
+
+/**
+ * @define noDefaultScheduler
+ * ===Scheduler:===
+ * This method does not operate by default on a particular [[Scheduler]].
+ *
+ * A class to add `Experimental/Beta` APIs in RxJava. These APIs can change at any time.
+ *
+ * `import rx.lang.scala.ExperimentalAPIs._` to enable them.
+ */
+class ExperimentalObservable[+T](private val o: Observable[T]) {
+
+  /**
+   * Instructs an [[Observable]] will block the producer thread if the source emits items faster than its [[Observer]] can consume them
+   *
+   * <img width="640" height="245" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/bp.obp.block.png" alt="">
+   *
+   * The producer side can emit up to `maxQueueLength` onNext elements without blocking, but the
+   * consumer side considers the amount its downstream requested through `Producer.request(n)`
+   * and doesn't emit more than requested even if more is available. For example, using
+   * `onBackpressureBlock(384).observeOn(Schedulers.io())` will not throw a MissingBackpressureException.
+   *
+   * Note that if the upstream Observable does support backpressure, this operator ignores that capability
+   * and doesn't propagate any backpressure requests from downstream.
+   *
+   * $noDefaultScheduler
+   *
+   * @param maxQueueLength the maximum number of items the producer can emit without blocking
+   * @return an [[Observable]] that will block the producer thread if the source emits items faster than its [[Observer]] can consume them
+   * @see <a href="http://reactivex.io/documentation/operators/backpressure.html">ReactiveX operators documentation: backpressure operators</a>
+   */
+  def onBackpressureBlock(maxQueueLength: Int): Observable[T] = {
+    o.asJavaObservable.onBackpressureBlock(maxQueueLength)
+  }
+
+  /**
+   * Instructs an [[Observable]] will block the producer thread if the source emits items faster than its [[Observer]] can consume them
+   *
+   * <img width="640" height="245" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/bp.obp.block.png" alt="">
+   *
+   * The producer side can emit up to the system-wide ring buffer size onNext elements without blocking, but
+   * the consumer side considers the amount its downstream requested through `Producer.request(n)`
+   * and doesn't emit more than requested even if available.
+   *
+   * Note that if the upstream Observable does support backpressure, this operator ignores that capability
+   * and doesn't propagate any backpressure requests from downstream.
+   *
+   * $noDefaultScheduler
+   *
+   * @return an [[Observable]] that will block the producer thread if the source emits items faster than its [[Observer]] can consume them
+   * @see <a href="http://reactivex.io/documentation/operators/backpressure.html">ReactiveX operators documentation: backpressure operators</a>
+   */
+  def onBackpressureBlock: Observable[T] = {
+    o.asJavaObservable.onBackpressureBlock()
+  }
+
+  /**
+   * An [[Observable]] wrapping the source one that will invokes the given action when it receives a request for more items.
+   *
+   * $noDefaultScheduler
+   *
+   * @param onRequest the action that gets called when an [[Observer]] requests items from this [[Observable]]
+   * @return an [[Observable]] that will call `onRequest` when appropriate
+   * @see <a href="http://reactivex.io/documentation/operators/do.html">ReactiveX operators documentation: Do</a>
+   */
+  def doOnRequest(onRequest: Long => Unit): Observable[T] = {
+    o.asJavaObservable.doOnRequest(new Action1[java.lang.Long] {
+      override def call(request: java.lang.Long): Unit = onRequest(request)
+    })
+  }
+
+  /**
+   * Instructs an [[Observable]] that is emitting items faster than its [[Observer]] can consume them to buffer up to
+   * a given amount of items until they can be emitted. The resulting [[Observable]] will emit
+   * `BufferOverflowException` as soon as the buffer's capacity is exceeded, drop all undelivered
+   * items, and unsubscribe from the source.
+   *
+   * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/bp.obp.buffer.png" alt="">
+   *
+   * $noDefaultScheduler
+   *
+   * @param capacity capacity of the internal buffer.
+   * @return an [[Observable]] that will buffer items up to the given capacity
+   * @see <a href="http://reactivex.io/documentation/operators/backpressure.html">ReactiveX operators documentation: backpressure operators</a>
+   */
+  def onBackpressureBufferWithCapacity(capacity: Long): Observable[T] = {
+    // Use `onBackpressureBufferWithCapacity` because if not, it will conflict with `Observable.onBackpressureBuffer`
+    o.asJavaObservable.onBackpressureBuffer(capacity)
+  }
+
+  /**
+   * Instructs an [[Observable]] that is emitting items faster than its [[Observer]] can consume them to buffer up to
+   * a given amount of items until they can be emitted. The resulting [[Observable]] will emit
+   * `BufferOverflowException` as soon as the buffer's capacity is exceeded, drop all undelivered
+   * items, unsubscribe from the source, and notify `onOverflow`.
+   *
+   * <img width="640" height="300" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/bp.obp.buffer.png" alt="">
+   *
+   * $noDefaultScheduler
+   *
+   * @param capacity capacity of the internal buffer.
+   * @param onOverflow an action to run when the buffer's capacity is exceeded. This is a by-name parameter.
+   * @return the source Observable modified to buffer items up to the given capacity
+   * @see <a href="http://reactivex.io/documentation/operators/backpressure.html">ReactiveX operators documentation: backpressure operators</a>
+   * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+   */
+  def onBackpressureBufferWithCapacity(capacity: Long, onOverflow: => Unit): Observable[T] = {
+    // Use `onBackpressureBufferWithCapacity` because if not, it will conflict with `Observable.onBackpressureBuffer`
+    o.asJavaObservable.onBackpressureBuffer(capacity, new Action0 {
+      override def call(): Unit = onOverflow
+    })
+  }
+
+  /**
+   * Returns an [[Observable]] that emits the items emitted by the source [[Observable]] or the items of an alternate
+   * [[Observable]] if the source [[Observable]] is empty.
+   *
+   * $noDefaultScheduler
+   *
+   * @param alternate the alternate [[Observable]] to subscribe to if the source does not emit any items
+   * @return an [[Observable]] that emits the items emitted by the source [[Observable]] or the items of an
+   *         alternate [[Observable]] if the source [[Observable]] is empty.
+   */
+  def switchIfEmpty[U >: T](alternate: Observable[U]): Observable[U] = {
+    val jo = o.asJavaObservable.asInstanceOf[rx.Observable[U]]
+    toScalaObservable[U](jo.switchIfEmpty(alternate.asJavaObservable))
+  }
+
+  /**
+   * Merges the specified [[Observable]] into this [[Observable]] sequence by using the `resultSelector`
+   * function only when the source [[Observable]] (this instance) emits an item.
+   *
+   * <img width="640" height="380" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/withLatestFrom.png" alt="">
+   *
+   * $noDefaultScheduler
+   *
+   * @param other the other [[Observable]]
+   * @param resultSelector the function to call when this [[Observable]] emits an item and the other [[Observable]] has already
+   *                       emitted an item, to generate the item to be emitted by the resulting [[Observable]]
+   * @return an [[Observable]] that merges the specified [[Observable]] into this [[Observable]] by using the
+   *         `resultSelector` function only when the source [[Observable]] sequence (this instance) emits an item
+   * @see <a href="http://reactivex.io/documentation/operators/combinelatest.html">ReactiveX operators documentation: CombineLatest</a>
+   */
+  def withLatestFrom[U, R](other: Observable[U])(resultSelector: (T, U) => R): Observable[R] = {
+    val func = new Func2[T, U, R] {
+      override def call(t1: T, t2: U): R = resultSelector(t1, t2)
+    }
+    toScalaObservable[R](o.asJavaObservable.withLatestFrom(other.asJavaObservable, func))
+  }
+
+  /**
+   * Returns an [[Observable]] that emits items emitted by the source [[Observable]], checks the specified predicate
+   * for each item, and then completes if the condition is satisfied.
+   *
+   * <img width="640" height="305" src="https://raw.github.com/wiki/ReactiveX/RxJava/images/rx-operators/takeUntil.p.png" alt="">
+   *
+   * The difference between this operator and `takeWhile(T => Boolean)` is that here, the condition is
+   * evaluated '''after''' the item is emitted.
+   *
+   * $noDefaultScheduler
+   *
+   * @param stopPredicate a function that evaluates an item emitted by the source [[Observable]] and returns a Boolean
+   * @return an [[Observable]] that first emits items emitted by the source [[Observable]], checks the specified
+   *         condition after each item, and then completes if the condition is satisfied.
+   * @see <a href="http://reactivex.io/documentation/operators/takeuntil.html">ReactiveX operators documentation: TakeUntil</a>
+   * @see [[Observable.takeWhile]]
+   */
+  def takeUntil(stopPredicate: T => Boolean): Observable[T] = {
+    val func = new Func1[T, java.lang.Boolean] {
+      override def call(t: T): java.lang.Boolean = stopPredicate(t)
+    }
+    toScalaObservable[T](o.asJavaObservable.takeUntil(func))
+  }
+
+  /**
+   * Returns an [[Observable]] that emits items based on applying a function that you supply to each item emitted
+   * by the source [[Observable]] , where that function returns an [[Observable]] , and then merging those resulting
+   * [[Observable]]s and emitting the results of this merger, while limiting the maximum number of concurrent
+   * subscriptions to these [[Observable]]s.
+   *
+   * $$noDefaultScheduler
+   *
+   * @param f a function that, when applied to an item emitted by the source [[Observable]], returns an [[Observable]]
+   * @param maxConcurrent the maximum number of [[Observable]]s that may be subscribed to concurrently
+   * @return an [[Observable]] that emits the result of applying the transformation function to each item emitted
+   *         by the source [[Observable]] and merging the results of the [[Observable]]s obtained from this transformation
+   * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+   */
+  def flatMapWithMaxConcurrent[R](f: T => Observable[R], maxConcurrent: Int): Observable[R] = {
+    toScalaObservable[R](o.asJavaObservable.flatMap[R](new Func1[T, rx.Observable[_ <: R]] {
+      def call(t1: T): rx.Observable[_ <: R] = {
+        f(t1).asJavaObservable
+      }
+    }, maxConcurrent))
+  }
+
+  /**
+   * Returns an [[Observable]] that applies a function to each item emitted or notification raised by the source
+   * [[Observable]]  and then flattens the [[Observable]] s returned from these functions and emits the resulting items,
+   * while limiting the maximum number of concurrent subscriptions to these [[Observable]]s.
+   *
+   * $noDefaultScheduler
+   *
+   * @param onNext a function that returns an [[Observable]] to merge for each item emitted by the source [[Observable]]
+   * @param onError a function that returns an [[Observable]] to merge for an onError notification from the source [[Observable]]
+   * @param onCompleted a function that returns an [[Observable]] to merge for an onCompleted notification from the source [[Observable]]
+   * @param maxConcurrent the maximum number of [[Observable]]s that may be subscribed to concurrently
+   * @return an [[Observable]] that emits the results of merging the [[Observable]]s returned from applying the
+   *         specified functions to the emissions and notifications of the source [[Observable]]
+   * @see <a href="http://reactivex.io/documentation/operators/flatmap.html">ReactiveX operators documentation: FlatMap</a>
+   */
+  def flatMapWithMaxConcurrent[R](onNext: T => Observable[R], onError: Throwable => Observable[R], onCompleted: () => Observable[R], maxConcurrent: Int): Observable[R] = {
+    val jOnNext = new Func1[T, rx.Observable[_ <: R]] {
+      override def call(t: T): rx.Observable[_ <: R] = onNext(t).asJavaObservable
+    }
+    val jOnError = new Func1[Throwable, rx.Observable[_ <: R]] {
+      override def call(e: Throwable): rx.Observable[_ <: R] = onError(e).asJavaObservable
+    }
+    val jOnCompleted = new Func0[rx.Observable[_ <: R]] {
+      override def call(): rx.Observable[_ <: R] = onCompleted().asJavaObservable
+    }
+    toScalaObservable[R](o.asJavaObservable.flatMap[R](jOnNext, jOnError, jOnCompleted, maxConcurrent))
+  }
+}
+
+object ExperimentalAPIs {
+  implicit def toExperimentalObservable[T](o: Observable[T]): ExperimentalObservable[T] = new ExperimentalObservable(o)
+}


### PR DESCRIPTION
This PR added `ExperimentalObservable` to add RxJava Beta/Experimental APIs, proposed in #100.
