### PR TITLE
Move examples

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,7 +31,7 @@ o1.switchIfEmpty(alternate).foreach(println)
 o2.switchIfEmpty(alternate).foreach(println)
 ```
 
-See more examples in [ExperimentalAPIExamples](https://github.com/ReactiveX/RxScala/blob/0.x/examples/src/test/scala/rx/lang/scala/examples/ExperimentalAPIExamples.scala)
+See more examples in [ExperimentalAPIExamples](https://github.com/ReactiveX/RxScala/blob/0.x/examples/src/test/scala/examples/ExperimentalAPIExamples.scala)
 
 Because the APIs in ExperimentalAPIs depends on unstable APIs in RxJava, if you would like to use a custom RxJava version,
 it's better to check the compatibility in https://github.com/ReactiveX/RxScala#versioning

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ def never: Observable[Nothing]
 
 Also, the Scala Observable is fully covariant in its type parameter, whereas the Java Observable only achieves partial covariance due to limitations of Java's type system (or if you can fix this, your suggestions are very welcome).
 
-For more examples, see [RxScalaDemo.scala](https://github.com/ReactiveX/RxScala/blob/0.x/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala).
+For more examples, see [RxScalaDemo.scala](https://github.com/ReactiveX/RxScala/blob/0.x/examples/src/test/scala/examples/RxScalaDemo.scala).
 
 Scala code using Rx should only import members from `rx.lang.scala` and below.
 

--- a/examples/src/test/java/examples/MovieLibUsage.java
+++ b/examples/src/test/java/examples/MovieLibUsage.java
@@ -13,12 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package rx.lang.scala.examples;
+package examples;
 
 import rx.Observable;
 import rx.functions.Action1;
-import rx.lang.scala.examples.Movie;
-import rx.lang.scala.examples.MovieLib;
 import static rx.lang.scala.JavaConversions.toScalaObservable;
 
 public class MovieLibUsage {

--- a/examples/src/test/scala/examples/APICoverage.scala
+++ b/examples/src/test/scala/examples/APICoverage.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package rx.lang.scala.examples
+package examples
 
 import scala.collection.mutable
 

--- a/examples/src/test/scala/examples/ExperimentalAPIExamples.scala
+++ b/examples/src/test/scala/examples/ExperimentalAPIExamples.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package rx.lang.scala.examples
+package examples
 
 import scala.concurrent.duration._
 import scala.language.postfixOps

--- a/examples/src/test/scala/examples/MovieLib.scala
+++ b/examples/src/test/scala/examples/MovieLib.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package rx.lang.scala.examples
+package examples
 
 import rx.lang.scala.Observable
 

--- a/examples/src/test/scala/examples/Olympics.scala
+++ b/examples/src/test/scala/examples/Olympics.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package rx.lang.scala.examples
+package examples
 
 import rx.lang.scala.Observable
 import scala.concurrent.duration._

--- a/examples/src/test/scala/examples/RxScalaDemo.scala
+++ b/examples/src/test/scala/examples/RxScalaDemo.scala
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package rx.lang.scala.examples
+package examples
 
 import java.io.IOException
 import java.util.concurrent.CountDownLatch
@@ -708,8 +708,8 @@ class RxScalaDemo extends JUnitSuite {
     import Notification._
     val oc1: Notification[Nothing] = OnCompleted
     val oc2: Notification[Int] = OnCompleted
-    val oc3: rx.Notification[_ <: Int] = oc2.asJavaNotification
-    val oc4: rx.Notification[_ <: Any] = oc2.asJavaNotification
+    val oc3: rx.Notification[_ <: Int] = JavaConversions.toJavaNotification(oc2)
+    val oc4: rx.Notification[_ <: Any] = JavaConversions.toJavaNotification(oc2)
   }
 
   @Test def takeWhileWithIndexAlternative {

--- a/examples/src/test/scala/examples/TestSchedulerExample.scala
+++ b/examples/src/test/scala/examples/TestSchedulerExample.scala
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package rx.lang.scala.examples
-
 import scala.concurrent.duration.DurationInt
 import scala.language.postfixOps
 import org.junit.Test
@@ -24,6 +22,7 @@ import org.scalatest.junit.JUnitSuite
 import rx.lang.scala._
 import rx.lang.scala.schedulers.TestScheduler
 import rx.observers.TestObserver
+import rx.lang.scala.JavaConversions._
 
 class TestSchedulerExample extends JUnitSuite {
 
@@ -35,7 +34,7 @@ class TestSchedulerExample extends JUnitSuite {
     val o = Observable.interval(1 second, scheduler)
 
     // Wrap Java Observer in Scala Observer, then subscribe
-    val sub = o.subscribe(Observer(new TestObserver(observer)))
+    val sub = o.subscribe(toScalaObserver(new TestObserver(observer)))
 
     verify(observer, never).onNext(0L)
     verify(observer, never).onCompleted()

--- a/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala
+++ b/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala
@@ -1,0 +1,4 @@
+/**
+ * Moved to examples/src/test/scala/examples/RxScalaDemo.scala
+ * See https://github.com/ReactiveX/RxScala/blob/0.x/examples/src/test/scala/examples/RxScalaDemo.scala
+ */

--- a/src/main/scala/rx/lang/scala/Observable.scala
+++ b/src/main/scala/rx/lang/scala/Observable.scala
@@ -4813,8 +4813,8 @@ object Observable {
    * See <a href="http://go.microsoft.com/fwlink/?LinkID=205219">Rx Design Guidelines (PDF)</a> for detailed
    * information.
    *
-   * See `<a href="https://github.com/ReactiveX/RxScala/blob/0.x/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala">RxScalaDemo</a>.createExampleGood`
-   * and `<a href="https://github.com/ReactiveX/RxScala/blob/0.x/examples/src/test/scala/rx/lang/scala/examples/RxScalaDemo.scala">RxScalaDemo</a>.createExampleGood2`.
+   * See `<a href="https://github.com/ReactiveX/RxScala/blob/0.x/examples/src/test/scala/examples/RxScalaDemo.scala">RxScalaDemo</a>.createExampleGood`
+   * and `<a href="https://github.com/ReactiveX/RxScala/blob/0.x/examples/src/test/scala/examples/RxScalaDemo.scala">RxScalaDemo</a>.createExampleGood2`.
    *
    * @tparam T
    *            the type of the items that this Observable emits

--- a/src/main/scala/rx/lang/scala/schedulers/TestScheduler.scala
+++ b/src/main/scala/rx/lang/scala/schedulers/TestScheduler.scala
@@ -37,12 +37,13 @@ object TestScheduler {
  * @Test def testInterval() {
  *   import org.mockito.Matchers._
  *   import org.mockito.Mockito._
+ *   import rx.lang.scala.JavaConversions._
  *
  *   val scheduler = TestScheduler()
  *   val observer = mock(classOf[rx.Observer[Long]])
  *
  *   val o = Observable.interval(1 second, scheduler)
- *   val sub = o.subscribe(observer)
+ *   val sub = o.subscribe(toScalaObserver(new TestObserver(observer)))
  *
  *   verify(observer, never).onNext(0L)
  *   verify(observer, never).onCompleted()


### PR DESCRIPTION
This pull request moves the examples so that they no longer have access to private methods in the rx.lang.scala package. These examples being in the same package already made `TestScheduler.scala` not work out of the box.

As a novice RxScala-test-writer :sweat_smile: I did not understand at first that some JavaConversion was going on, as I missed that the mock class was mocking the Java variant of Observer. 
- Move examples
- Fix small missing java conversion in scaladoc
