### PR TITLE
Fix invalid wikipedia url in AsyncWiki example

### DIFF
--- a/examples/src/main/scala/AsyncWiki.scala
+++ b/examples/src/main/scala/AsyncWiki.scala
@@ -15,7 +15,7 @@ object AsyncWiki extends App {
             if (subscriber.isUnsubscribed) {
               return
             }
-            val url = "http://en.wikipedia.org/wiki/" + articleName
+            val url = "https://en.wikipedia.org/wiki/" + articleName
             val art = new Scanner(new URL(url).openStream()).useDelimiter("\\A").next()
             subscriber.onNext(art)
           }


### PR DESCRIPTION
When I run AsyncWiki example i got exception because wikipedia url changed:

```
[info] Running AsyncWiki 
[error] (Thread-6) java.util.NoSuchElementException
java.util.NoSuchElementException
        at java.util.Scanner.throwFor(Scanner.java:862)
        at java.util.Scanner.next(Scanner.java:1371)
        at AsyncWiki$$anonfun$fetchWikipediaArticleAsynchronously$1$$anon$1$$anonfun$run$1.apply(AsyncWiki.scala:19)
        at AsyncWiki$$anonfun$fetchWikipediaArticleAsynchronously$1$$anon$1$$anonfun$run$1.apply(AsyncWiki.scala:14)
        at scala.collection.IndexedSeqOptimized$class.foreach(IndexedSeqOptimized.scala:33)
        at scala.collection.mutable.WrappedArray.foreach(WrappedArray.scala:35)
        at AsyncWiki$$anonfun$fetchWikipediaArticleAsynchronously$1$$anon$1.run(AsyncWiki.scala:14)
        at java.lang.Thread.run(Thread.java:745)
```
