### PR TITLE
0.26.0 Release Note 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # RxScala Releases
 
+## Version 0.26.0 - TODO ([Maven Central](http://search.maven.org/#search%7Cga%7C1%7C%22rxscala%22%20AND%20g%3A%22io.reactivex%22))
+
+This release upgrades RxJava to 1.1.0 and removes deprecated APIs.
+
+### Pull Requests
+
+* [Pull 184] (https://github.com/ReactiveX/RxScala/pull/184) Bump to RxJava 1.1.0 and remove deprecated APIs
+
+Artifacts: [Maven Central](http://search.maven.org/#search%7Cga%7C1%7C%22rxscala%22%20AND%20g%3A%22io.reactivex%22)
+
 ## Version 0.25.1 - December 18th 2015 ([Maven Central](http://search.maven.org/#search%7Cga%7C1%7C%22rxscala%22%20AND%20g%3A%22io.reactivex%22))
 
 This release upgrades RxJava to 1.0.17 along with several experimental APIs including new `interval` overloads, `concatEager`, `concatMapEager`, `flattenDelayError` and `BlockingObservable.subscribe`.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Since RxScala is part of the RxJava family the communication channels are simila
 
 | RxScala version | Compatible RxJava version |
 | ------------------- | ------------------------- |
+| 0.26.* | 1.0.* |
 | 0.25.* | 1.0.* |
 | 0.24.* | 1.0.* |
 | 0.23.*<sup>[1]</sup> | 1.0.* |
@@ -96,6 +97,7 @@ you should use the corresponding version of RxJava as the following table:
 
 | RxScala version | Compatible RxJava version |
 | ------------------- | ------------------------- |
+| 0.26.0 | 1.1.0+ |
 | 0.25.1 | 1.0.17+ |
 | 0.25.0 | 1.0.11+ |
 | 0.24.1 | 1.0.8+ |

--- a/src/main/scala/rx/lang/scala/Observable.scala
+++ b/src/main/scala/rx/lang/scala/Observable.scala
@@ -5077,44 +5077,6 @@ object Observable {
   }
 
   /**
-   * Return an Observable that emits a 0L after the `initialDelay` and ever increasing
-   * numbers after each `period` of time thereafter, on a specified Scheduler.
-   * <p>
-   * <img width="640" height="200" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/timer.ps.png" alt="" />
-   *
-   * @param initialDelay
-   * the initial delay time to wait before emitting the first value of 0L
-   * @param period
-   * the period of time between emissions of the subsequent numbers
-   * @return an Observable that emits a 0L after the `initialDelay` and ever increasing
-   *         numbers after each `period` of time thereafter, while running on the given `scheduler`
-   */
-  @deprecated("Use [[Observable$.interval(initialDelay:scala\\.concurrent\\.duration\\.Duration,period:scala\\.concurrent\\.duration\\.Duration)* interval]] instead.", "0.25.1")
-  def timer(initialDelay: Duration, period: Duration): Observable[Long] = {
-    toScalaObservable[java.lang.Long](rx.Observable.timer(initialDelay.toNanos, period.toNanos, duration.NANOSECONDS)).map(_.longValue())
-  }
-
-  /**
-   * Return an Observable that emits a 0L after the `initialDelay` and ever increasing
-   * numbers after each `period` of time thereafter, on a specified Scheduler.
-   * <p>
-   * <img width="640" height="200" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/timer.ps.png" alt="" />
-   *
-   * @param initialDelay
-   * the initial delay time to wait before emitting the first value of 0L
-   * @param period
-   * the period of time between emissions of the subsequent numbers
-   * @param scheduler
-   * the scheduler on which the waiting happens and items are emitted
-   * @return an Observable that emits a 0L after the `initialDelay` and ever increasing
-   * numbers after each `period` of time thereafter, while running on the given `scheduler`
-   */
-  @deprecated("Use [[Observable$.interval(initialDelay:scala\\.concurrent\\.duration\\.Duration,period:scala\\.concurrent\\.duration\\.Duration,scheduler:rx\\.lang\\.scala\\.Scheduler)* interval]] instead.", "0.25.1")
-  def timer(initialDelay: Duration, period: Duration, scheduler: Scheduler): Observable[Long] = {
-    toScalaObservable[java.lang.Long](rx.Observable.timer(initialDelay.toNanos, period.toNanos, duration.NANOSECONDS, scheduler)).map(_.longValue())
-  }
-
-  /**
    * Returns an Observable that emits `0L` after a specified delay, and then completes.
    *
    * <img width="640" height="200" src="https://raw.githubusercontent.com/wiki/ReactiveX/RxJava/images/rx-operators/timer.png" alt="" />


### PR DESCRIPTION
- 0.26.0 Release Note 
- Remove two deprecated timer methods (no more deprecated APIs in the current codebase)
