### PR TITLE
Deprecate Observable.create

### DIFF
--- a/examples/src/test/scala/examples/RxScalaDemo.scala
+++ b/examples/src/test/scala/examples/RxScalaDemo.scala
@@ -740,21 +740,7 @@ class RxScalaDemo extends JUnitSuite {
       case _ => throw new IllegalArgumentException
     }
   }
-  
-  /**
-   * This is a bad way of using Observable.create, because even if the consumer unsubscribes,
-   * all elements are calculated.
-   */
-  @Test def createExampleBad() {
-    val o = Observable.create[String](observer => {
-      observer.onNext(calculateElement(0))
-      observer.onNext(calculateElement(1))
-      observer.onCompleted()
-      Subscription {}
-    })
-    o.take(1).subscribe(println(_))
-  }
-  
+
   /**
    * This is the good way of doing it: If the consumer unsubscribes, no more elements are 
    * calculated.

--- a/src/main/scala/rx/lang/scala/Observable.scala
+++ b/src/main/scala/rx/lang/scala/Observable.scala
@@ -4853,6 +4853,7 @@ object Observable {
    * @return
    *         an Observable that, when an [[rx.lang.scala.Observer]] subscribes to it, will execute the given function.
    */
+  @deprecated("Use [[Observable.apply]] instead", "0.26.2")
   def create[T](f: Observer[T] => Subscription): Observable[T] = {
     Observable(
       (subscriber: Subscriber[T]) => {

--- a/src/test/scala/rx/lang/scala/ObservableTest.scala
+++ b/src/test/scala/rx/lang/scala/ObservableTest.scala
@@ -256,22 +256,6 @@ class ObservableTests extends JUnitSuite {
   }
 
   @Test
-  def testCreate() {
-    var called = false
-    val o = Observable.create[String](observer => {
-      observer.onNext("a")
-      observer.onNext("b")
-      observer.onNext("c")
-      observer.onCompleted()
-      Subscription {
-        called = true
-      }
-    })
-    assertEquals(List("a", "b", "c"), o.toBlocking.toList)
-    assertTrue(called)
-  }
-
-  @Test
   def testToTraversable() {
     val o = Observable.just(1, 2, 3).toTraversable
     assertEquals(Seq(1, 2, 3), o.toBlocking.single)

--- a/src/test/scala/rx/lang/scala/SubscriptionTests.scala
+++ b/src/test/scala/rx/lang/scala/SubscriptionTests.scala
@@ -186,11 +186,8 @@ class SubscriptionTests extends JUnitSuite {
   @Test
   def testIssue85: Unit = {
     // https://github.com/ReactiveX/RxScala/issues/85
-    val xs = Observable.create[Nothing](o => {
+    val xs = Observable.apply[Nothing](o => {
       o.onCompleted()
-      Subscription {
-        // do nothing
-      }
     })
     val s = xs.subscribe()
     assertTrue(s.isUnsubscribed)


### PR DESCRIPTION
Let's deprecate `Observable.create` now. We can add it back when the coursera course is open again.
