### PR TITLE
Add assertValuesAndClear and something test features.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ crossScalaVersions in ThisBuild := Seq("2.10.6", "2.11.8", "2.12.0-M4")
 parallelExecution in Test := false
 
 libraryDependencies ++= Seq(
-  "io.reactivex" % "rxjava" % "1.1.6",
+  "io.reactivex" % "rxjava" % "1.1.9",
   "org.mockito" % "mockito-core" % "1.9.5" % "test",
   "junit" % "junit" % "4.11" % "test",
   "org.scalatest" %% "scalatest" % "2.2.6" % "test")

--- a/src/main/scala/rx/lang/scala/observers/TestSubscriber.scala
+++ b/src/main/scala/rx/lang/scala/observers/TestSubscriber.scala
@@ -259,6 +259,44 @@ class TestSubscriber[T] private[scala](jTestSubscriber: JTestSubscriber[T]) exte
   def assertValue(value: T): Unit = {
     jTestSubscriber.assertValue(value)
   }
+
+  /**
+   * $experimental Assert values if the received onNext events, in order, are the specified items
+   * and if so, clears the internal list of values.
+   *
+   * @param values the items to check
+   * @throws java.lang.AssertionError if the items emitted do not exactly match those specified by `values`
+   * @since (if this graduates from "Experimental" replace this parenthetical with the release number)
+   */
+  @Experimental
+  @throws[AssertionError]
+  def assertValuesAndClear(values: T*): Unit = {
+    jTestSubscriber.assertValuesAndClear(values.head, values.tail: _*)
+  }
+
+  /**
+   * Returns the committed number of onNext elements that are safe to be
+   * read from {@link #getOnNextEvents()} other threads.
+   *
+   * @return the committed number of onNext elements
+   */
+  def getValueCount(): Int = jTestSubscriber.getValueCount
+
+  /**
+   * Wait until the current committed value count is less than the expected amount
+   * by sleeping 1 unit at most timeout times and return true if at least
+   * the required amount of onNext values have been received.
+   *
+   * @param expected the expected number of onNext events
+   * @param timeout  the time to wait for the events
+   * @return true if the expected number of onNext events happened
+   * @throws InterruptedException if the sleep is interrupted
+   * @since (if this graduates from Experimental/Beta to supported, replace this parenthetical with the release number)
+   */
+  @Experimental
+  def awaitValueCount(expected: Int, timeout: Duration): Boolean = {
+    jTestSubscriber.awaitValueCount(expected, timeout.length, timeout.unit)
+  }
 }
 
 /**

--- a/src/test/scala-2.11/rx/lang/scala/completeness/TestSubscriberCompletenessKit.scala
+++ b/src/test/scala-2.11/rx/lang/scala/completeness/TestSubscriberCompletenessKit.scala
@@ -28,10 +28,12 @@ class TestSubscriberCompletenessKit extends CompletenessKit {
     "assertError(Class[_ <: Throwable])" -> "assertError(Class[_ <: Throwable])",
     "assertReceivedOnNext(List[T])" -> "assertValues(T*)",
     "getLastSeenThread()" -> "getLastSeenThread",
-    "getOnCompletedEvents()" -> "assertCompleted()",
+    "getCompletions()" -> "assertCompleted()",
     "getOnErrorEvents()" -> "getOnErrorEvents",
     "getOnNextEvents()" -> "getOnNextEvents",
     "isUnsubscribed()" -> "isUnsubscribed",
+    "assertValuesAndClear(T, T*)" -> "assertValuesAndClear(T*)",
+    "getValueCount()" -> "getValueCount()",
 
     "create()" -> "apply()",
     "create(Long)" -> "apply(Long)",

--- a/src/test/scala/rx/lang/scala/SubscriberTests.scala
+++ b/src/test/scala/rx/lang/scala/SubscriberTests.scala
@@ -15,6 +15,8 @@
  */
 package rx.lang.scala
 
+import rx.lang.scala.observers.TestSubscriber
+
 import scala.collection.mutable
 
 import org.junit.Test
@@ -181,5 +183,20 @@ class SubscriberTests extends JUnitSuite {
     assertTrue("onCompleted isn't called", completed)
     val zeros = new Array[Int](10).toList
     assertEquals(zeros, l)
+  }
+
+  @Test def testIssue202() {
+    // https://github.com/ReactiveX/RxScala/issues/202
+    val subject = Subject[Option[Unit]]()
+    val testSubscriber = TestSubscriber[Option[Unit]]()
+    subject.filter(_.isDefined).subscribe(testSubscriber)
+    testSubscriber.assertNoValues()
+    subject.onNext(None)
+    testSubscriber.assertNoValues()
+    subject.onNext(Some(()))
+    testSubscriber.assertValuesAndClear(Some(()))
+    testSubscriber.assertNoValues()
+    subject.onNext(None)
+    testSubscriber.assertNoValues()
   }
 }


### PR DESCRIPTION
However, this commit's test is failed because there are various changes between 1.1.6 and 1.1.9, and I cannot decide about these problems myself.

Something Problems:
  In `rx.Scheduler`, `when` method was appended.
  In `rx.Observable`, 24 methods are appended.

And, While I put `assertValuesAndClear`'s test into `SubscriberTests`, but you should move to appropriate place for this test or remove if this test is not needed.

You should consider this commit as reference or even it would be better to create your own from scratch.

**Please Don't Merge this PR as is!!!**
