### PR TITLE
Try & Option converters

### DIFF
--- a/src/main/scala/rx/lang/scala/Observable.scala
+++ b/src/main/scala/rx/lang/scala/Observable.scala
@@ -20,6 +20,7 @@ import rx.annotations.{Beta, Experimental}
 import rx.exceptions.OnErrorNotImplementedException
 import rx.functions.FuncN
 import rx.lang.scala.observables.{ConnectableObservable, ErrorDelayingObservable}
+
 import scala.concurrent.duration
 import java.util
 
@@ -30,6 +31,7 @@ import scala.collection.{Iterable, Traversable, immutable}
 import scala.collection.mutable.ArrayBuffer
 import scala.language.higherKinds
 import scala.reflect.ClassTag
+import scala.util.Try
 
 
 /**
@@ -5039,6 +5041,24 @@ object Observable {
    */
   def from[T](iterable: Iterable[T]): Observable[T] = {
     toScalaObservable(rx.Observable.from(iterable.asJava))
+  }
+
+  /**
+   * Converts a `Try` into an `Observable`.
+   *
+   * Implementation note: the value will be immediately emitted each time an [[rx.lang.scala.Observer]] subscribes.
+   * Since this occurs before the [[rx.lang.scala.Subscription]] is returned,
+   * it in not possible to unsubscribe from the sequence before it completes.
+   *
+   * @param t the source Try
+   * @tparam T the type of value in the Try, and the type of items to be emitted by the resulting Observable
+   * @return an Observable that either emits the value or the error in the Try.
+   */
+  def from[T](t: Try[T]): Observable[T] = {
+    t match {
+      case Success(s) => Observable.just(s)
+      case Failure(e) => Observable.error(e)
+    }
   }
 
   /**

--- a/src/main/scala/rx/lang/scala/Observable.scala
+++ b/src/main/scala/rx/lang/scala/Observable.scala
@@ -20,7 +20,6 @@ import rx.annotations.{Beta, Experimental}
 import rx.exceptions.OnErrorNotImplementedException
 import rx.functions.FuncN
 import rx.lang.scala.observables.{ConnectableObservable, ErrorDelayingObservable}
-
 import scala.concurrent.duration
 import java.util
 

--- a/src/main/scala/rx/lang/scala/package.scala
+++ b/src/main/scala/rx/lang/scala/package.scala
@@ -15,6 +15,8 @@
  */
 package rx.lang
 
+import _root_.scala.util.{Try, Success, Failure}
+
 /**
  * This package contains all classes that RxScala users need.
  *
@@ -27,5 +29,20 @@ package object scala {
    */
   implicit class ObservableExtensions[T](val source: Iterable[T]) extends AnyVal {
       def toObservable: Observable[T] = {  Observable.from(source) }
+  }
+
+  implicit class TryToObservable[T](val t: Try[T]) extends AnyVal {
+    def toObservable: Observable[T] = {
+      t match {
+        case Success(s) => Observable.just(s)
+        case Failure(e) => Observable.error(e)
+      }
+    }
+  }
+
+  implicit class OptionToObservable[T](val opt: Option[T]) extends AnyVal {
+    def toObservable: Observable[T] = {
+      opt.map(Observable.just(_)).getOrElse(Observable.empty)
+    }
   }
 }

--- a/src/main/scala/rx/lang/scala/package.scala
+++ b/src/main/scala/rx/lang/scala/package.scala
@@ -31,18 +31,11 @@ package object scala {
       def toObservable: Observable[T] = {  Observable.from(source) }
   }
 
-  implicit class TryToObservable[T](val t: Try[T]) extends AnyVal {
-    def toObservable: Observable[T] = {
-      t match {
-        case Success(s) => Observable.just(s)
-        case Failure(e) => Observable.error(e)
-      }
-    }
+  implicit class TryToObservable[T](val tryT: Try[T]) extends AnyVal {
+    def toObservable: Observable[T] = Observable.from(tryT)
   }
 
   implicit class OptionToObservable[T](val opt: Option[T]) extends AnyVal {
-    def toObservable: Observable[T] = {
-      opt.map(Observable.just(_)).getOrElse(Observable.empty)
-    }
+    def toObservable: Observable[T] = Observable.from(opt)
   }
 }

--- a/src/test/scala/rx/lang/scala/ConversionsTests.scala
+++ b/src/test/scala/rx/lang/scala/ConversionsTests.scala
@@ -1,0 +1,55 @@
+package rx.lang.scala
+
+import org.junit.Test
+import org.scalatest.junit.JUnitSuite
+import rx.lang.scala.observers.TestSubscriber
+
+import scala.util.{Failure, Success}
+
+class ConversionsTests extends JUnitSuite {
+
+  @Test
+  def testTrySuccessConversion() = {
+    val success = Success("abc")
+    val observer = TestSubscriber[String]()
+    success.toObservable.subscribe(observer)
+
+    observer.assertValue("abc")
+    observer.assertNoErrors()
+    observer.assertCompleted()
+  }
+
+  @Test
+  def testTryFailureConversion() = {
+    val error = new IllegalArgumentException("test error")
+    val failure = Failure[String](error)
+    val observer = TestSubscriber[String]()
+    failure.toObservable.subscribe(observer)
+
+    observer.assertNoValues()
+    observer.assertError(error)
+    observer.assertNotCompleted()
+  }
+
+  @Test
+  def testOptionSomeConversion() = {
+    val some = Some("abc")
+    val observer = TestSubscriber[String]()
+    some.toObservable.subscribe(observer)
+
+    observer.assertValue("abc")
+    observer.assertNoErrors()
+    observer.assertCompleted()
+  }
+
+  @Test
+  def testOptionNoneConversion() = {
+    val some = None
+    val observer = TestSubscriber[String]()
+    some.toObservable.subscribe(observer)
+
+    observer.assertNoValues()
+    observer.assertNoErrors()
+    observer.assertCompleted()
+  }
+}

--- a/src/test/scala/rx/lang/scala/TryOptionConversionsTests.scala
+++ b/src/test/scala/rx/lang/scala/TryOptionConversionsTests.scala
@@ -6,7 +6,7 @@ import rx.lang.scala.observers.TestSubscriber
 
 import scala.util.{Failure, Success}
 
-class ConversionsTests extends JUnitSuite {
+class TryOptionConversionsTests extends JUnitSuite {
 
   @Test
   def testTrySuccessConversion() = {

--- a/src/test/scala/rx/lang/scala/TryOptionConversionsTests.scala
+++ b/src/test/scala/rx/lang/scala/TryOptionConversionsTests.scala
@@ -33,7 +33,7 @@ class TryOptionConversionsTests extends JUnitSuite {
 
   @Test
   def testOptionSomeConversion() = {
-    val some = Some("abc")
+    val some = Option("abc")
     val observer = TestSubscriber[String]()
     some.toObservable.subscribe(observer)
 
@@ -44,7 +44,7 @@ class TryOptionConversionsTests extends JUnitSuite {
 
   @Test
   def testOptionNoneConversion() = {
-    val some = None
+    val some = Option.empty[String]
     val observer = TestSubscriber[String]()
     some.toObservable.subscribe(observer)
 


### PR DESCRIPTION
Refer to issue #209 for the start of the discussion.

This PR adds a `.toObservable` converter for `scala.util.Try` and `scala.Option` as well as a `Observable.from` wrapper for `scala.util.Try`. 
