### PR TITLE
Add UnicastSubject

### DIFF
--- a/src/main/scala/rx/lang/scala/subjects/UnicastSubject.scala
+++ b/src/main/scala/rx/lang/scala/subjects/UnicastSubject.scala
@@ -19,25 +19,29 @@ import rx.annotations.Experimental
 import rx.lang.scala.Subject
 
 /**
-  * A `Subject` variant which buffers events until a single `Subscriber` arrives and replays them to it
-  * and potentially switches to direct delivery once the `Subscriber` caught up and requested an unlimited
-  * amount. In this case, the buffered values are no longer retained. If the `Subscriber`
-  * requests a limited amount, queueing is involved and only those values are retained which
-  * weren't requested by the `Subscriber` at that time.
+  * $experimental A `Subject` variant which buffers events until a single `Subscriber` arrives and replays
+  * them to it and potentially switches to direct delivery once the `Subscriber` caught up and requested an
+  * unlimited amount. In this case, the buffered values are no longer retained. If the `Subscriber` requests
+  * a limited amount, queueing is involved and only those values are retained which weren't requested by the
+  * `Subscriber` at that time.
+  *
+  * @define experimental
+  * <span class="badge badge-red" style="float: right;">EXPERIMENTAL</span>
   */
 @Experimental
 object UnicastSubject {
 
   /**
-    * Constructs an empty `UnicastSubject` instance with the default capacity hint of 16 elements.
+    * $experimental Constructs an empty `UnicastSubject` instance with the default capacity hint of 16 elements.
     *
     * @tparam T the input and output value type
     * @return the created `UnicastSubject` instance
     */
+  @Experimental
   def apply[T](): UnicastSubject[T] = new UnicastSubject[T](rx.subjects.UnicastSubject.create[T]())
 
   /**
-    * Constructs an empty UnicastSubject instance with a capacity hint.
+    * $experimental Constructs an empty UnicastSubject instance with a capacity hint.
     * <p>The capacity hint determines the internal queue's island size: the larger
     * it is the less frequent allocation will happen if there is no subscriber
     * or the subscriber hasn't caught up.
@@ -46,6 +50,7 @@ object UnicastSubject {
     * @tparam T the input and output value type
     * @return the created `UnicastSubject` instance
     */
+  @Experimental
   def apply[T](capacity: Int): UnicastSubject[T] = new UnicastSubject[T](rx.subjects.UnicastSubject.create(capacity))
 }
 

--- a/src/main/scala/rx/lang/scala/subjects/UnicastSubject.scala
+++ b/src/main/scala/rx/lang/scala/subjects/UnicastSubject.scala
@@ -1,0 +1,52 @@
+/**
+  * Copyright 2013 Netflix, Inc.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *     http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+package rx.lang.scala.subjects
+
+import rx.annotations.Experimental
+import rx.lang.scala.Subject
+
+/**
+  * A `Subject` variant which buffers events until a single `Subscriber` arrives and replays them to it
+  * and potentially switches to direct delivery once the `Subscriber` caught up and requested an unlimited
+  * amount. In this case, the buffered values are no longer retained. If the `Subscriber`
+  * requests a limited amount, queueing is involved and only those values are retained which
+  * weren't requested by the `Subscriber` at that time.
+  */
+@Experimental
+object UnicastSubject {
+
+  /**
+    * Constructs an empty `UnicastSubject` instance with the default capacity hint of 16 elements.
+    *
+    * @tparam T the input and output value type
+    * @return the created `UnicastSubject` instance
+    */
+  def apply[T](): UnicastSubject[T] = new UnicastSubject[T](rx.subjects.UnicastSubject.create[T]())
+
+  /**
+    * Constructs an empty UnicastSubject instance with a capacity hint.
+    * <p>The capacity hint determines the internal queue's island size: the larger
+    * it is the less frequent allocation will happen if there is no subscriber
+    * or the subscriber hasn't caught up.
+    *
+    * @param capacity the capacity hint for the internal queue
+    * @tparam T the input and output value type
+    * @return the created `UnicastSubject` instance
+    */
+  def apply[T](capacity: Int): UnicastSubject[T] = new UnicastSubject[T](rx.subjects.UnicastSubject.create(capacity))
+}
+
+private [scala] class UnicastSubject[T] private [scala] (val asJavaSubject: rx.subjects.UnicastSubject[T]) extends Subject[T] {}


### PR DESCRIPTION
This pull request adds a wrapper for JavaRx `UnicastSubject`. Although the `Subject` is experimental, I would like to see a Scala wrapper for it as it's very useful in one of my projects.

I read #100, but I'm still not sure of how I should mark classes as experimental. I opted to use the annotation that is used in Java, but please tell me if you want it another way and I'll change it.
