### PR TITLE
Implement SyncOnSubscribe and AsyncOnSubscribe

### DIFF
--- a/src/main/scala/rx/lang/scala/Notification.scala
+++ b/src/main/scala/rx/lang/scala/Notification.scala
@@ -63,6 +63,16 @@ sealed trait Notification[+T] {
   }
 
   def apply(observer: Observer[T]): Unit = accept(observer)
+
+  // TODO: Should this be public or private to rx.lang.scala?
+  def map[U](f: T => U): Notification[U] = {
+    this match {
+      case Notification.OnNext(value) => Notification.OnNext(f(value))
+      // TODO: Or do we want to cast here? Notification.OnError[T] is not a Notification[U]
+      case Notification.OnError(error) => Notification.OnError(error)
+      case Notification.OnCompleted => Notification.OnCompleted
+    }
+  }
 }
 
 /**

--- a/src/main/scala/rx/lang/scala/Notification.scala
+++ b/src/main/scala/rx/lang/scala/Notification.scala
@@ -64,11 +64,9 @@ sealed trait Notification[+T] {
 
   def apply(observer: Observer[T]): Unit = accept(observer)
 
-  // TODO: Should this be public or private to rx.lang.scala?
   def map[U](f: T => U): Notification[U] = {
     this match {
       case Notification.OnNext(value) => Notification.OnNext(f(value))
-      // TODO: Or do we want to cast here? Notification.OnError[T] is not a Notification[U]
       case Notification.OnError(error) => Notification.OnError(error)
       case Notification.OnCompleted => Notification.OnCompleted
     }

--- a/src/main/scala/rx/lang/scala/Observable.scala
+++ b/src/main/scala/rx/lang/scala/Observable.scala
@@ -4943,7 +4943,7 @@ object Observable {
     * @see [[observables.SyncOnSubscribe.stateless]]
     */
   @Experimental
-  def create[S,T](syncOnSubscribe: SyncOnSubscribe[S,T]): Observable[T] = syncOnSubscribe.toObservable
+  def create[S,T](syncOnSubscribe: SyncOnSubscribe[S,T]): Observable[T] = toScalaObservable[T](rx.Observable.create(syncOnSubscribe))
 
   /**
     * Returns an Observable that respects the back-pressure semantics. When the returned Observable is
@@ -4964,7 +4964,7 @@ object Observable {
     * @see [[observables.AsyncOnSubscribe.stateless]]
     */
   @Experimental
-  def create[S,T](asyncOnSubscribe: AsyncOnSubscribe[S,T]): Observable[T] = asyncOnSubscribe.toObservable
+  def create[S,T](asyncOnSubscribe: AsyncOnSubscribe[S,T]): Observable[T] = toScalaObservable[T](rx.Observable.create(asyncOnSubscribe))
 
   /**
    * Returns an Observable that will execute the specified function when someone subscribes to it.

--- a/src/main/scala/rx/lang/scala/Observable.scala
+++ b/src/main/scala/rx/lang/scala/Observable.scala
@@ -19,7 +19,8 @@ package rx.lang.scala
 import rx.annotations.{Beta, Experimental}
 import rx.exceptions.OnErrorNotImplementedException
 import rx.functions.FuncN
-import rx.lang.scala.observables.{ConnectableObservable, ErrorDelayingObservable}
+import rx.lang.scala.observables.{AsyncOnSubscribe, ConnectableObservable, ErrorDelayingObservable, SyncOnSubscribe}
+
 import scala.concurrent.duration
 import java.util
 
@@ -4918,6 +4919,52 @@ object Observable {
     val fWrong: Subscriber[T] => Unit = o => Subscription{}
   }
   */
+
+  /**
+    * Returns an Observable that respects the back-pressure semantics. When the returned Observable is
+    * subscribed to it will initiate the given [[observables.SyncOnSubscribe]]'s life cycle for
+    * generating events.
+    *
+    * Note: the `SyncOnSubscribe` provides a generic way to fulfill data by iterating
+    * over a (potentially stateful) function (e.g. reading data off of a channel, a parser). If your
+    * data comes directly from an asynchronous/potentially concurrent source then consider using [[observables.AsyncOnSubscribe]].
+    *
+    * $supportBackpressure
+    *
+    * $noDefaultScheduler
+    *
+    * @tparam T the type of the items that this Observable emits
+    * @tparam S the state type
+    * @param syncOnSubscribe
+    *          an implementation of `SyncOnSubscribe`. There are many creation methods on the object for convenience.
+    * @return an Observable that, when a [[Subscriber]] subscribes to it, will use the specified `SyncOnSubscribe` to generate events
+    * @see [[observables.SyncOnSubscribe.stateful]]
+    * @see [[observables.SyncOnSubscribe.singleState]]
+    * @see [[observables.SyncOnSubscribe.stateless]]
+    */
+  @Experimental
+  def create[S,T](syncOnSubscribe: SyncOnSubscribe[S,T]): Observable[T] = syncOnSubscribe.toObservable
+
+  /**
+    * Returns an Observable that respects the back-pressure semantics. When the returned Observable is
+    * subscribed to it will initiate the given [[observables.AsyncOnSubscribe]]'s life cycle for
+    * generating events.
+    *
+    * $supportBackpressure
+    *
+    * $noDefaultScheduler
+    *
+    * @tparam T the type of the items that this Observable emits
+    * @tparam S the state type
+    * @param asyncOnSubscribe
+    *          an implementation of `AsyncOnSubscribe`. There are many creation methods on the object for convenience.
+    * @return an Observable that, when a [[Subscriber]] subscribes to it, will use the specified `AsyncOnSubscribe` to generate events
+    * @see [[observables.AsyncOnSubscribe.stateful]]
+    * @see [[observables.AsyncOnSubscribe.singleState]]
+    * @see [[observables.AsyncOnSubscribe.stateless]]
+    */
+  @Experimental
+  def create[S,T](asyncOnSubscribe: AsyncOnSubscribe[S,T]): Observable[T] = asyncOnSubscribe.toObservable
 
   /**
    * Returns an Observable that will execute the specified function when someone subscribes to it.

--- a/src/main/scala/rx/lang/scala/observables/AsyncOnSubscribe.scala
+++ b/src/main/scala/rx/lang/scala/observables/AsyncOnSubscribe.scala
@@ -11,7 +11,7 @@ import rx.lang.scala.{Notification, Observable}
   * * `generator` is called to provide an initial state on each new subscription
   * * `next` is called with the last state and a `requested` amount of items to provide a new state
   *     and an `Observable` that (potentially asynchronously) emits up to `requested` items.
-  * * `onUnsubscribe` is called with the state provides by the last next when the observer unsubscribes
+  * * `onUnsubscribe` is called with the state provided by the last `next` call when the observer unsubscribes
   */
 object AsyncOnSubscribe {
 

--- a/src/main/scala/rx/lang/scala/observables/AsyncOnSubscribe.scala
+++ b/src/main/scala/rx/lang/scala/observables/AsyncOnSubscribe.scala
@@ -4,117 +4,82 @@ import rx.annotations.Experimental
 import rx.lang.scala.{Notification, Observable, Observer}
 
 /**
-  * An utility class to create observables that start acting when subscribed to and respond correctly
-  * to back pressure requests from subscribers.
+  * An utility class to create [[Observable]]s that start acting when subscribed to and responds
+  * correctly to back pressure requests from subscribers.
+  *
+  * Semantics:
+  * * `generator` is called to provide an initial state on each new subscription
+  * * `next` is called with the last state and a `requested` amount of items to provide a new state
+  *     and an [[Observable]] that (potentially asynchronously) emits up to `requested` items.
+  * * `onUnsubscribe` is called with the state provides by the last next when the observer unsubscribes
+  *
+  * @tparam S the type of the user-define state
+  * @tparam T the type items that this `AsyncOnSubscribe` will emit.
   */
-object AsyncOnSubscribe {
-  /**
-    * Generates an `Observable` that synchronously calls the provided `next` function
-    * to generate data to downstream subscribers.
-    *
-    * @tparam T the type of the generated values
-    * @tparam S the type of the associated state with each Subscriber
-    * @param generator generates the initial state value
-    * @param next produces data to the downstream subscriber
-    * @param onUnsubscribe clean up behavior
-    * @return An Observable that emits data downstream in a protocol compatible with back-pressure.
-    * @see rx.observables.AsyncOnSubscribe.createStateful
-    */
-  @Experimental
-  def createStateful[S, T](generator: () => S)(next: (S, Long, Observer[Observable[_ <: T]]) => S, onUnsubscribe: S => Unit = (_:S) => ()): Observable[T] =
-    new AsyncOnSubscribeImpl[S, T](generator, next, onUnsubscribe).toObservable
+class AsyncOnSubscribe[S,T](val generator: () => S,
+                            val next: (S, Long) => (Notification[Observable[T]], S),
+                            val onUnsubscribe: S => Unit) { self =>
+  import rx.lang.scala.JavaConversions._
 
-  /**
-    * Generates an `Observable` that synchronously calls the provided `next` function
-    * to generate data to downstream subscribers.
-    *
-    * @tparam T the type of the generated values
-    * @tparam S the type of the associated state with each Subscriber
-    * @param generator generates the initial state value
-    * @param next produces data to the downstream subscriber
-    * @param onUnsubscribe clean up behavior
-    * @return An Observable that emits data downstream in a protocol compatible with back-pressure.
-    * @see rx.observables.AsyncOnSubscribe.createSingleState
-    */
-  @Experimental
-  def createSingleState[S, T](generator: () => S)(next: (S, Long, Observer[Observable[_ <: T]]) => Unit, onUnsubscribe: S => Unit = (_:S) => ()): Observable[T] =
-    new AsyncOnSubscribeImpl[S, T](generator, (state, req, obs) => {next(state,req,obs); state}, onUnsubscribe).toObservable
-
-  /**
-    * Generates an `Observable` that synchronously calls the provided `next` function
-    * to generate data to downstream subscribers.
-    *
-    * @tparam T the type of the generated values
-    * @param next produces data to the downstream subscriber
-    * @param onUnsubscribe clean up behavior
-    * @return An Observable that emits data downstream in a protocol compatible with back-pressure.
-    * @see rx.observables.AsyncOnSubscribe.createStateless
-    */
-  @Experimental
-  def createStateless[T](next: (Long, Observer[Observable[_ <: T]]) => Unit, onUnsubscribe: () => Unit = () => ()): Observable[T] =
-    new AsyncOnSubscribeImpl[Unit, T](() => (), (_, req, obs) => next(req, obs), _ => onUnsubscribe()).toObservable
-
-  /**
-    * Generates an `Observable` that calls the provided `next` function to generate observables with at most the requested amount of items.
-    *
-    * @tparam T the type of the generated values
-    * @tparam S the type of the associated state with each Subscriber
-    * @param generator generates the initial state value
-    * @param next produces an observable with at most the requested amount of items for the stream
-    * @param onUnsubscribe clean up behavior
-    * @return An observable that emits data downstream in a protocol compatible with back-pressure.
-    */
-  @Experimental
-  def apply[S, T](generator: () => S)(next: (S, Long) => (Notification[Observable[_ <: T]], S), onUnsubscribe: S => Unit = (_:S) => ()): Observable[T] = {
-    val nextF: (S, Long, Observer[Observable[_ <: T]]) => S =
-      (state, requested, observer) => next(state, requested) match {
+  private[scala] val asJavaAsyncOnSubscribe = new rx.observables.AsyncOnSubscribe[S,T] {
+    override def generateState(): S = generator()
+    override def next(state: S, requested: Long, observer: rx.Observer[rx.Observable[_ <: T]]): S =
+      self.next(state, requested) match {
         case (notification, nextState) =>
-          notification.accept(observer)
+          toJavaNotification(notification.map(toJavaObservable)).accept(observer)
           nextState
       }
-    new AsyncOnSubscribeImpl[S, T](generator, nextF, onUnsubscribe).toObservable
+    override def onUnsubscribe(state: S): Unit = self.onUnsubscribe(state)
   }
 
+  def toObservable: Observable[T] = toScalaObservable[T](rx.Observable.create(asJavaAsyncOnSubscribe))
+}
+
+object AsyncOnSubscribe {
+
   /**
-    * Generates an `Observable` that calls the provided `next` function to generate observables with at most the requested amount of items.
+    * Alias for [[AsyncOnSubscribe.stateful]]
+    * @see [[AsyncOnSubscribe.stateful]]
+    */
+  @Experimental
+  def apply[S,T](generator: () => S)(next: (S, Long) => (Notification[Observable[T]], S), onUnsubscribe: S => Unit = (_:S) => ()): AsyncOnSubscribe[S,T] =
+    stateful(generator)(next, onUnsubscribe)
+
+  /**
+    * Generates a stateful [[AsyncOnSubscribe]]
+    *
+    * @tparam T the type of the generated values
+    * @tparam S the type of the associated state with each Subscriber
+    * @param generator generates the initial state value
+    * @param next produces observables which contain data for the stream
+    * @param onUnsubscribe clean up behavior
+    */
+  @Experimental
+  def stateful[S, T](generator: () => S)(next: (S, Long) => (Notification[Observable[T]], S), onUnsubscribe: S => Unit = (_:S) => ()): AsyncOnSubscribe[S,T] =
+    new AsyncOnSubscribe[S, T](generator, next, onUnsubscribe)
+
+  /**
+    * Generates a [[AsyncOnSubscribe]] which does not generate a new state in `next`
     *
     * @tparam T the type of the generated values
     * @tparam S the type of the associated state with each Subscriber
     * @param generator generates the state value
-    * @param next produces an observable with at most the requested amount of items for the stream
+    * @param next produces observables which contain data for the stream
     * @param onUnsubscribe clean up behavior
-    * @return An observable that emits data downstream in a protocol compatible with back-pressure.
     */
   @Experimental
-  def applySingleState[S, T](generator: () => S)(next: (S, Long) => Notification[Observable[_ <: T]], onUnsubscribe: S => Unit = (_:S) => ()): Observable[T] =
-    apply[S, T](generator)((s,r) => (next(s,r), s), onUnsubscribe)
+  def singleState[S, T](generator: () => S)(next: (S, Long) => Notification[Observable[T]], onUnsubscribe: S => Unit = (_:S) => ()): AsyncOnSubscribe[S,T] =
+    stateful[S, T](generator)((s,r) => (next(s,r), s), onUnsubscribe)
 
   /**
-    * Generates an `Observable` that calls the provided `next` function to generate observables with at most the requested amount of items.
+    * Generates a stateless [[AsyncOnSubscribe]], useful when the state is closed over in `next` or the `SyncOnSubscribe` inherently does not have a state
     *
     * @tparam T the type of the generated values
-    * @param next produces an observable with at most the requested amount of items for the stream
+    * @param next produces observables which contain data for the stream
     * @param onUnsubscribe clean up behavior
-    * @return An observable that emits data downstream in a protocol compatible with back-pressure.
     */
   @Experimental
-  def applyStateless[T](next: Long => Notification[Observable[_ <: T]], onUnsubscribe: () => Unit = () => ()) =
-    apply[Unit, T](() => ())((_,r) => (next(r), ()), _ => onUnsubscribe())
+  def stateless[T](next: Long => Notification[Observable[T]], onUnsubscribe: () => Unit = () => ()) =
+    stateful[Unit, T](() => ())((_,r) => (next(r), ()), _ => onUnsubscribe())
 
-  private[scala] class AsyncOnSubscribeImpl[S,T](val generatorF: () => S, val nextF: (S, Long, Observer[Observable[_ <: T]]) => S, val onUnsubscribeF: S => Unit) {
-    import rx.lang.scala.JavaConversions._
-
-    private[scala] val asJavaAsyncOnSubscribe = new rx.observables.AsyncOnSubscribe[S,T] {
-      override def generateState(): S = generatorF()
-      override def next(state: S, requested: Long, observer: rx.Observer[rx.Observable[_ <: T]]): S =
-        nextF(state, requested, Observer(
-          onNext = t => observer.onNext(t.asJavaObservable),
-          onError = e => observer.onError(e),
-          onCompleted = () => observer.onCompleted()
-        ))
-      override def onUnsubscribe(state: S): Unit = onUnsubscribeF(state)
-    }
-
-    def toObservable = toScalaObservable(rx.Observable.create(asJavaAsyncOnSubscribe))
-  }
 }

--- a/src/main/scala/rx/lang/scala/observables/AsyncOnSubscribe.scala
+++ b/src/main/scala/rx/lang/scala/observables/AsyncOnSubscribe.scala
@@ -1,0 +1,120 @@
+package rx.lang.scala.observables
+
+import rx.annotations.Experimental
+import rx.lang.scala.{Notification, Observable, Observer}
+
+/**
+  * An utility class to create observables that start acting when subscribed to and respond correctly
+  * to back pressure requests from subscribers.
+  */
+object AsyncOnSubscribe {
+  /**
+    * Generates an `Observable` that synchronously calls the provided `next` function
+    * to generate data to downstream subscribers.
+    *
+    * @tparam T the type of the generated values
+    * @tparam S the type of the associated state with each Subscriber
+    * @param generator generates the initial state value
+    * @param next produces data to the downstream subscriber
+    * @param onUnsubscribe clean up behavior
+    * @return An Observable that emits data downstream in a protocol compatible with back-pressure.
+    * @see rx.observables.AsyncOnSubscribe.createStateful
+    */
+  @Experimental
+  def createStateful[S, T](generator: () => S)(next: (S, Long, Observer[Observable[_ <: T]]) => S, onUnsubscribe: S => Unit = (_:S) => ()): Observable[T] =
+    new AsyncOnSubscribeImpl[S, T](generator, next, onUnsubscribe).toObservable
+
+  /**
+    * Generates an `Observable` that synchronously calls the provided `next` function
+    * to generate data to downstream subscribers.
+    *
+    * @tparam T the type of the generated values
+    * @tparam S the type of the associated state with each Subscriber
+    * @param generator generates the initial state value
+    * @param next produces data to the downstream subscriber
+    * @param onUnsubscribe clean up behavior
+    * @return An Observable that emits data downstream in a protocol compatible with back-pressure.
+    * @see rx.observables.AsyncOnSubscribe.createSingleState
+    */
+  @Experimental
+  def createSingleState[S, T](generator: () => S)(next: (S, Long, Observer[Observable[_ <: T]]) => Unit, onUnsubscribe: S => Unit = (_:S) => ()): Observable[T] =
+    new AsyncOnSubscribeImpl[S, T](generator, (state, req, obs) => {next(state,req,obs); state}, onUnsubscribe).toObservable
+
+  /**
+    * Generates an `Observable` that synchronously calls the provided `next` function
+    * to generate data to downstream subscribers.
+    *
+    * @tparam T the type of the generated values
+    * @param next produces data to the downstream subscriber
+    * @param onUnsubscribe clean up behavior
+    * @return An Observable that emits data downstream in a protocol compatible with back-pressure.
+    * @see rx.observables.AsyncOnSubscribe.createStateless
+    */
+  @Experimental
+  def createStateless[T](next: (Long, Observer[Observable[_ <: T]]) => Unit, onUnsubscribe: () => Unit = () => ()): Observable[T] =
+    new AsyncOnSubscribeImpl[Unit, T](() => (), (_, req, obs) => next(req, obs), _ => onUnsubscribe()).toObservable
+
+  /**
+    * Generates an `Observable` that calls the provided `next` function to generate observables with at most the requested amount of items.
+    *
+    * @tparam T the type of the generated values
+    * @tparam S the type of the associated state with each Subscriber
+    * @param generator generates the initial state value
+    * @param next produces an observable with at most the requested amount of items for the stream
+    * @param onUnsubscribe clean up behavior
+    * @return An observable that emits data downstream in a protocol compatible with back-pressure.
+    */
+  @Experimental
+  def apply[S, T](generator: () => S)(next: (S, Long) => (Notification[Observable[_ <: T]], S), onUnsubscribe: S => Unit = (_:S) => ()): Observable[T] = {
+    val nextF: (S, Long, Observer[Observable[_ <: T]]) => S =
+      (state, requested, observer) => next(state, requested) match {
+        case (notification, nextState) =>
+          notification.accept(observer)
+          nextState
+      }
+    new AsyncOnSubscribeImpl[S, T](generator, nextF, onUnsubscribe).toObservable
+  }
+
+  /**
+    * Generates an `Observable` that calls the provided `next` function to generate observables with at most the requested amount of items.
+    *
+    * @tparam T the type of the generated values
+    * @tparam S the type of the associated state with each Subscriber
+    * @param generator generates the state value
+    * @param next produces an observable with at most the requested amount of items for the stream
+    * @param onUnsubscribe clean up behavior
+    * @return An observable that emits data downstream in a protocol compatible with back-pressure.
+    */
+  @Experimental
+  def applySingleState[S, T](generator: () => S)(next: (S, Long) => Notification[Observable[_ <: T]], onUnsubscribe: S => Unit = (_:S) => ()): Observable[T] =
+    apply[S, T](generator)((s,r) => (next(s,r), s), onUnsubscribe)
+
+  /**
+    * Generates an `Observable` that calls the provided `next` function to generate observables with at most the requested amount of items.
+    *
+    * @tparam T the type of the generated values
+    * @param next produces an observable with at most the requested amount of items for the stream
+    * @param onUnsubscribe clean up behavior
+    * @return An observable that emits data downstream in a protocol compatible with back-pressure.
+    */
+  @Experimental
+  def applyStateless[T](next: Long => Notification[Observable[_ <: T]], onUnsubscribe: () => Unit = () => ()) =
+    apply[Unit, T](() => ())((_,r) => (next(r), ()), _ => onUnsubscribe())
+
+  private[scala] class AsyncOnSubscribeImpl[S,T](val generatorF: () => S, val nextF: (S, Long, Observer[Observable[_ <: T]]) => S, val onUnsubscribeF: S => Unit) {
+    import rx.lang.scala.JavaConversions._
+
+    private[scala] val asJavaAsyncOnSubscribe = new rx.observables.AsyncOnSubscribe[S,T] {
+      override def generateState(): S = generatorF()
+      override def next(state: S, requested: Long, observer: rx.Observer[rx.Observable[_ <: T]]): S =
+        nextF(state, requested, Observer(
+          onNext = t => observer.onNext(t.asJavaObservable),
+          onError = e => observer.onError(e),
+          onCompleted = () => observer.onCompleted()
+        ))
+      override def onUnsubscribe(state: S): Unit = onUnsubscribeF(state)
+    }
+
+    def toObservable = toScalaObservable(rx.Observable.create(asJavaAsyncOnSubscribe))
+  }
+}

--- a/src/main/scala/rx/lang/scala/observables/AsyncOnSubscribe.scala
+++ b/src/main/scala/rx/lang/scala/observables/AsyncOnSubscribe.scala
@@ -21,7 +21,7 @@ object AsyncOnSubscribe {
     */
   @Experimental
   def apply[S,T](generator: () => S)(next: (S, Long) => (Notification[Observable[T]], S), onUnsubscribe: S => Unit = (_:S) => ()): AsyncOnSubscribe[S,T] =
-    stateful(generator)(next, onUnsubscribe)
+    stateful[S, T](generator)(next, onUnsubscribe)
 
   /**
     * Generates a stateful [[AsyncOnSubscribe]]

--- a/src/main/scala/rx/lang/scala/observables/SyncOnSubscribe.scala
+++ b/src/main/scala/rx/lang/scala/observables/SyncOnSubscribe.scala
@@ -1,0 +1,115 @@
+package rx.lang.scala.observables
+
+import rx.annotations.Experimental
+import rx.lang.scala.{Notification, Observable, Observer}
+
+/**
+  * An utility class to create observables that start acting when subscribed to and respond correctly
+  * to back pressure requests from subscribers.
+  */
+object SyncOnSubscribe {
+  /**
+    * Generates an `Observable` that synchronously calls the provided `next` function
+    * to generate data to downstream subscribers.
+    *
+    * @tparam T the type of the generated values
+    * @tparam S the type of the associated state with each Subscriber
+    * @param generator generates the initial state value
+    * @param next produces data to the downstream subscriber
+    * @param onUnsubscribe clean up behavior
+    * @return An Observable that emits data downstream in a protocol compatible with back-pressure.
+    * @see rx.observables.AsyncOnSubscribe.createStateful
+    */
+  @Experimental
+  def createStateful[S, T](generator: () => S)(next: (S, Observer[_ >: T]) => S, onUnsubscribe: S => Unit = (_:S) => ()): Observable[T] =
+    new SyncOnSubscribeImpl(generator, next, onUnsubscribe).toObservable
+
+  /**
+    * Generates an `Observable` that synchronously calls the provided `next` function
+    * to generate data to downstream subscribers.
+    *
+    * @tparam T the type of the generated values
+    * @tparam S the type of the associated state with each Subscriber
+    * @param generator generates the initial state value
+    * @param next produces data to the downstream subscriber
+    * @param onUnsubscribe clean up behavior
+    * @return An Observable that emits data downstream in a protocol compatible with back-pressure.
+    * @see rx.observables.AsyncOnSubscribe.createSingleState
+    */
+  @Experimental
+  def createSingleState[S,T](generator: () => S)(next: (S, Observer[_ >: T]) => Unit, onUnsubscribe: S => Unit = (_:S) => ()): Observable[T] =
+    new SyncOnSubscribeImpl[S,T](generator, (s, obs) => { next(s, obs); s }, onUnsubscribe).toObservable
+
+  /**
+    * Generates an `Observable` that synchronously calls the provided `next` function
+    * to generate data to downstream subscribers.
+    *
+    * @tparam T the type of the generated values
+    * @param next produces data to the downstream subscriber
+    * @param onUnsubscribe clean up behavior
+    * @return An Observable that emits data downstream in a protocol compatible with back-pressure.
+    * @see rx.observables.AsyncOnSubscribe.createStateless
+    */
+  @Experimental
+  def createStateless[T](next: Observer[_ >: T] => Unit, onUnsubscribe: () => Unit = () => Unit): Observable[T] =
+    new SyncOnSubscribeImpl[Unit, T](() => (), (_, obs) => next(obs), (_:Unit) => onUnsubscribe()).toObservable
+
+  /**
+    * Generates an Observable that calls the provided `next` function to generate data for the stream.
+    *
+    * @tparam T the type of the generated values
+    * @tparam S the type of the associated state with each Subscriber
+    * @param generator generates the initial state value
+    * @param next produces data for the stream
+    * @param onUnsubscribe clean up behavior
+    * @return An observable that emits data downstream in a protocol compatible with back-pressure.
+    */
+  @Experimental
+  def apply[S, T](generator: () => S)(next: S => (Notification[T], S), onUnsubscribe: S => Unit = (_:S) => ()): Observable[T] = {
+    val nextF: (S, Observer[_ >: T]) => S =
+      (state, obs) => next(state) match {
+        case (notification, nextState) =>
+          notification.accept(obs)
+          nextState
+      }
+    new SyncOnSubscribeImpl(generator, nextF, onUnsubscribe).toObservable
+  }
+
+  /**
+    * Generates an Observable that calls the provided `next` function to generate data for the stream.
+    *
+    * @tparam T the type of the generated values
+    * @tparam S the type of the associated state with each Subscriber
+    * @param generator generates the state value
+    * @param next produces data for the stream
+    * @param onUnsubscribe clean up behavior
+    * @return An observable that emits data downstream in a protocol compatible with back-pressure.
+    */
+  @Experimental
+  def applySingleState[S,T](generator: () => S)(next: S => Notification[T], onUnsubscribe: S => Unit = (_:S) => ()): Observable[T] =
+    apply(generator)(s => (next(s),s), onUnsubscribe)
+
+  /**
+    * Generates an `Observable` that synchronously calls the provided `next` function to generate data for the stream.
+    *
+    * @tparam T the type of the generated values
+    * @param next produces data for the stream
+    * @param onUnsubscribe clean up behavior
+    * @return An Observable that emits data downstream in a protocol compatible with back-pressure.
+    */
+  @Experimental
+  def applyStateless[T](next: () => Notification[T], onUnsubscribe: () => Unit = () => ()) =
+    apply(() => ())(_ => (next(), ()), _ => onUnsubscribe())
+
+  private[scala] class SyncOnSubscribeImpl[S,T](val generatorF: () => S, val nextF: (S, Observer[_ >: T]) => S, val onUnsubscribeF: S => Unit) {
+    import rx.lang.scala.JavaConversions._
+
+    private[scala] val asJavaSyncOnSubscribe = new rx.observables.SyncOnSubscribe[S,T] {
+      override def generateState(): S = generatorF()
+      override def next(state: S, observer: rx.Observer[_ >: T]): S = nextF(state, observer)
+      override def onUnsubscribe(state: S): Unit = onUnsubscribeF(state)
+    }
+
+    def toObservable = toScalaObservable(rx.Observable.create(asJavaSyncOnSubscribe))
+  }
+}

--- a/src/main/scala/rx/lang/scala/observables/SyncOnSubscribe.scala
+++ b/src/main/scala/rx/lang/scala/observables/SyncOnSubscribe.scala
@@ -13,14 +13,14 @@ import rx.lang.scala.{Notification, Observable}
   * * `onUnsubscribe` is called with the state provides by the last next when the observer unsubscribes
   */
 object SyncOnSubscribe {
-  
+
   /**
     * Alias for [[SyncOnSubscribe.stateful]]
     * @see [[SyncOnSubscribe.stateful]]
     */
   @Experimental
   def apply[S, T](generator: () => S)(next: S => (Notification[T], S), onUnsubscribe: S => Unit = (_:S) => ()): SyncOnSubscribe[S,T] =
-    stateful(generator)(next, onUnsubscribe)
+    stateful[S, T](generator)(next, onUnsubscribe)
 
   /**
     * Generates a stateful [[SyncOnSubscribe]]
@@ -61,7 +61,7 @@ object SyncOnSubscribe {
     */
   @Experimental
   def singleState[S,T](generator: () => S)(next: S => Notification[T], onUnsubscribe: S => Unit = (_:S) => ()): SyncOnSubscribe[S,T] =
-    apply(generator)(s => (next(s),s), onUnsubscribe)
+    apply[S, T](generator)(s => (next(s),s), onUnsubscribe)
 
   /**
     * Generates a stateless [[SyncOnSubscribe]], useful when the state is closed over in `next` or the `SyncOnSubscribe` inherently does not have a state
@@ -72,6 +72,6 @@ object SyncOnSubscribe {
     */
   @Experimental
   def stateless[T](next: () => Notification[T], onUnsubscribe: () => Unit = () => ()) =
-    apply(() => ())(_ => (next(), ()), _ => onUnsubscribe())
+    apply[Unit, T](() => ())(_ => (next(), ()), _ => onUnsubscribe())
 
 }

--- a/src/main/scala/rx/lang/scala/observables/SyncOnSubscribe.scala
+++ b/src/main/scala/rx/lang/scala/observables/SyncOnSubscribe.scala
@@ -10,7 +10,7 @@ import rx.lang.scala.{Notification, Observable}
   * Semantics:
   * * `generator` is called to provide an initial state on each new subscription
   * * `next` is called with the last state to provide a data item and a new state for the next `next` call
-  * * `onUnsubscribe` is called with the state provides by the last next when the observer unsubscribes
+  * * `onUnsubscribe` is called with the state provided by the last `next` call when the observer unsubscribes
   */
 object SyncOnSubscribe {
 

--- a/src/main/scala/rx/lang/scala/observables/SyncOnSubscribe.scala
+++ b/src/main/scala/rx/lang/scala/observables/SyncOnSubscribe.scala
@@ -1,115 +1,84 @@
 package rx.lang.scala.observables
 
 import rx.annotations.Experimental
-import rx.lang.scala.{Notification, Observable, Observer}
+import rx.lang.scala.{Notification, Observable}
 
 /**
-  * An utility class to create observables that start acting when subscribed to and respond correctly
-  * to back pressure requests from subscribers.
+  * An utility class to create `Observable`s that start acting when subscribed to and responds
+  * correctly to back pressure requests from subscribers.
+  *
+  * Semantics:
+  * * `generator` is called to provide an initial state on each new subscription
+  * * `next` is called with the last state to provide a data item and a new state for the next `next` call
+  * * `onUnsubscribe` is called with the state provides by the last next when the observer unsubscribes
+  *
+  * @tparam S the type of the user-define state used
+  * @tparam T the type items that this `SyncOnSubscribe` will emit.
   */
+class SyncOnSubscribe[S,T](val generator: () => S,
+                            val next: S => (Notification[T], S),
+                            val onUnsubscribe: S => Unit) { self =>
+  import rx.lang.scala.JavaConversions._
+
+  private[scala] val asJavaSyncOnSubscribe = new rx.observables.SyncOnSubscribe[S,T] {
+    override def generateState(): S = generator()
+    override def next(state: S, observer: rx.Observer[_ >: T]): S =
+      self.next(state) match {
+        case (notification, nextState) =>
+          toJavaNotification(notification).accept(observer)
+          nextState
+      }
+    override def onUnsubscribe(state: S): Unit = self.onUnsubscribe(state)
+  }
+
+  def toObservable: Observable[T] = toScalaObservable[T](rx.Observable.create(asJavaSyncOnSubscribe))
+}
+
 object SyncOnSubscribe {
-  /**
-    * Generates an `Observable` that synchronously calls the provided `next` function
-    * to generate data to downstream subscribers.
-    *
-    * @tparam T the type of the generated values
-    * @tparam S the type of the associated state with each Subscriber
-    * @param generator generates the initial state value
-    * @param next produces data to the downstream subscriber
-    * @param onUnsubscribe clean up behavior
-    * @return An Observable that emits data downstream in a protocol compatible with back-pressure.
-    * @see rx.observables.AsyncOnSubscribe.createStateful
-    */
-  @Experimental
-  def createStateful[S, T](generator: () => S)(next: (S, Observer[_ >: T]) => S, onUnsubscribe: S => Unit = (_:S) => ()): Observable[T] =
-    new SyncOnSubscribeImpl(generator, next, onUnsubscribe).toObservable
 
   /**
-    * Generates an `Observable` that synchronously calls the provided `next` function
-    * to generate data to downstream subscribers.
-    *
-    * @tparam T the type of the generated values
-    * @tparam S the type of the associated state with each Subscriber
-    * @param generator generates the initial state value
-    * @param next produces data to the downstream subscriber
-    * @param onUnsubscribe clean up behavior
-    * @return An Observable that emits data downstream in a protocol compatible with back-pressure.
-    * @see rx.observables.AsyncOnSubscribe.createSingleState
+    * Alias for [[SyncOnSubscribe.stateful]]
+    * @see [[SyncOnSubscribe.stateful]]
     */
   @Experimental
-  def createSingleState[S,T](generator: () => S)(next: (S, Observer[_ >: T]) => Unit, onUnsubscribe: S => Unit = (_:S) => ()): Observable[T] =
-    new SyncOnSubscribeImpl[S,T](generator, (s, obs) => { next(s, obs); s }, onUnsubscribe).toObservable
+  def apply[S, T](generator: () => S)(next: S => (Notification[T], S), onUnsubscribe: S => Unit = (_:S) => ()): SyncOnSubscribe[S,T] =
+    stateful(generator)(next, onUnsubscribe)
 
   /**
-    * Generates an `Observable` that synchronously calls the provided `next` function
-    * to generate data to downstream subscribers.
-    *
-    * @tparam T the type of the generated values
-    * @param next produces data to the downstream subscriber
-    * @param onUnsubscribe clean up behavior
-    * @return An Observable that emits data downstream in a protocol compatible with back-pressure.
-    * @see rx.observables.AsyncOnSubscribe.createStateless
-    */
-  @Experimental
-  def createStateless[T](next: Observer[_ >: T] => Unit, onUnsubscribe: () => Unit = () => Unit): Observable[T] =
-    new SyncOnSubscribeImpl[Unit, T](() => (), (_, obs) => next(obs), (_:Unit) => onUnsubscribe()).toObservable
-
-  /**
-    * Generates an Observable that calls the provided `next` function to generate data for the stream.
+    * Generates a stateful [[SyncOnSubscribe]]
     *
     * @tparam T the type of the generated values
     * @tparam S the type of the associated state with each Subscriber
     * @param generator generates the initial state value
     * @param next produces data for the stream
     * @param onUnsubscribe clean up behavior
-    * @return An observable that emits data downstream in a protocol compatible with back-pressure.
     */
   @Experimental
-  def apply[S, T](generator: () => S)(next: S => (Notification[T], S), onUnsubscribe: S => Unit = (_:S) => ()): Observable[T] = {
-    val nextF: (S, Observer[_ >: T]) => S =
-      (state, obs) => next(state) match {
-        case (notification, nextState) =>
-          notification.accept(obs)
-          nextState
-      }
-    new SyncOnSubscribeImpl(generator, nextF, onUnsubscribe).toObservable
-  }
+  def stateful[S, T](generator: () => S)(next: S => (Notification[T], S), onUnsubscribe: S => Unit = (_:S) => ()): SyncOnSubscribe[S,T] =
+    new SyncOnSubscribe(generator, next, onUnsubscribe)
 
   /**
-    * Generates an Observable that calls the provided `next` function to generate data for the stream.
+    * Generates a [[SyncOnSubscribe]] which does not generate a new state in `next`
     *
     * @tparam T the type of the generated values
     * @tparam S the type of the associated state with each Subscriber
     * @param generator generates the state value
     * @param next produces data for the stream
     * @param onUnsubscribe clean up behavior
-    * @return An observable that emits data downstream in a protocol compatible with back-pressure.
     */
   @Experimental
-  def applySingleState[S,T](generator: () => S)(next: S => Notification[T], onUnsubscribe: S => Unit = (_:S) => ()): Observable[T] =
+  def singleState[S,T](generator: () => S)(next: S => Notification[T], onUnsubscribe: S => Unit = (_:S) => ()): SyncOnSubscribe[S,T] =
     apply(generator)(s => (next(s),s), onUnsubscribe)
 
   /**
-    * Generates an `Observable` that synchronously calls the provided `next` function to generate data for the stream.
+    * Generates a stateless [[SyncOnSubscribe]], useful when the state is closed over in `next` or the `SyncOnSubscribe` inherently does not have a state
     *
     * @tparam T the type of the generated values
     * @param next produces data for the stream
     * @param onUnsubscribe clean up behavior
-    * @return An Observable that emits data downstream in a protocol compatible with back-pressure.
     */
   @Experimental
-  def applyStateless[T](next: () => Notification[T], onUnsubscribe: () => Unit = () => ()) =
+  def stateless[T](next: () => Notification[T], onUnsubscribe: () => Unit = () => ()) =
     apply(() => ())(_ => (next(), ()), _ => onUnsubscribe())
 
-  private[scala] class SyncOnSubscribeImpl[S,T](val generatorF: () => S, val nextF: (S, Observer[_ >: T]) => S, val onUnsubscribeF: S => Unit) {
-    import rx.lang.scala.JavaConversions._
-
-    private[scala] val asJavaSyncOnSubscribe = new rx.observables.SyncOnSubscribe[S,T] {
-      override def generateState(): S = generatorF()
-      override def next(state: S, observer: rx.Observer[_ >: T]): S = nextF(state, observer)
-      override def onUnsubscribe(state: S): Unit = onUnsubscribeF(state)
-    }
-
-    def toObservable = toScalaObservable(rx.Observable.create(asJavaSyncOnSubscribe))
-  }
 }

--- a/src/main/scala/rx/lang/scala/observables/SyncOnSubscribe.scala
+++ b/src/main/scala/rx/lang/scala/observables/SyncOnSubscribe.scala
@@ -11,31 +11,9 @@ import rx.lang.scala.{Notification, Observable}
   * * `generator` is called to provide an initial state on each new subscription
   * * `next` is called with the last state to provide a data item and a new state for the next `next` call
   * * `onUnsubscribe` is called with the state provides by the last next when the observer unsubscribes
-  *
-  * @tparam S the type of the user-define state used
-  * @tparam T the type items that this `SyncOnSubscribe` will emit.
   */
-class SyncOnSubscribe[S,T](val generator: () => S,
-                            val next: S => (Notification[T], S),
-                            val onUnsubscribe: S => Unit) { self =>
-  import rx.lang.scala.JavaConversions._
-
-  private[scala] val asJavaSyncOnSubscribe = new rx.observables.SyncOnSubscribe[S,T] {
-    override def generateState(): S = generator()
-    override def next(state: S, observer: rx.Observer[_ >: T]): S =
-      self.next(state) match {
-        case (notification, nextState) =>
-          toJavaNotification(notification).accept(observer)
-          nextState
-      }
-    override def onUnsubscribe(state: S): Unit = self.onUnsubscribe(state)
-  }
-
-  def toObservable: Observable[T] = toScalaObservable[T](rx.Observable.create(asJavaSyncOnSubscribe))
-}
-
 object SyncOnSubscribe {
-
+  
   /**
     * Alias for [[SyncOnSubscribe.stateful]]
     * @see [[SyncOnSubscribe.stateful]]
@@ -54,8 +32,23 @@ object SyncOnSubscribe {
     * @param onUnsubscribe clean up behavior
     */
   @Experimental
-  def stateful[S, T](generator: () => S)(next: S => (Notification[T], S), onUnsubscribe: S => Unit = (_:S) => ()): SyncOnSubscribe[S,T] =
-    new SyncOnSubscribe(generator, next, onUnsubscribe)
+  def stateful[S, T](generator: () => S)(next: S => (Notification[T], S), onUnsubscribe: S => Unit = (_:S) => ()): SyncOnSubscribe[S,T] = {
+    // The anonymous class shadows these names
+    val nextF = next
+    val onUnsubscribeF = onUnsubscribe
+
+    new rx.observables.SyncOnSubscribe[S,T] {
+      import rx.lang.scala.JavaConversions._
+      override def generateState(): S = generator()
+      override def next(state: S, observer: rx.Observer[_ >: T]): S =
+        nextF(state) match {
+          case (notification, nextState) =>
+            toJavaNotification(notification).accept(observer)
+            nextState
+        }
+      override def onUnsubscribe(state: S): Unit = onUnsubscribeF(state)
+    }
+  }
 
   /**
     * Generates a [[SyncOnSubscribe]] which does not generate a new state in `next`

--- a/src/main/scala/rx/lang/scala/observables/package.scala
+++ b/src/main/scala/rx/lang/scala/observables/package.scala
@@ -25,6 +25,6 @@ package rx.lang.scala
  * and a pair `(startFunction, observable)` instead of `ConnectableObservable`. 
  */
 package object observables {
-  type SyncOnSubscribe[S, T] = rx.observables.SyncOnSubscribe[S, T]
-  type AsyncOnSubscribe[S, T] = rx.observables.AsyncOnSubscribe[S, T]
+  type SyncOnSubscribe[S, +T] = rx.observables.SyncOnSubscribe[S, _ <: T]
+  type AsyncOnSubscribe[S, +T] = rx.observables.AsyncOnSubscribe[S, _ <: T]
 }

--- a/src/main/scala/rx/lang/scala/observables/package.scala
+++ b/src/main/scala/rx/lang/scala/observables/package.scala
@@ -24,4 +24,7 @@ package rx.lang.scala
  * in Scala, because we use a pair `(key, observable)` instead of `GroupedObservable`
  * and a pair `(startFunction, observable)` instead of `ConnectableObservable`. 
  */
-package object observables {}
+package object observables {
+  type SyncOnSubscribe[S, T] = rx.observables.SyncOnSubscribe[S, T]
+  type AsyncOnSubscribe[S, T] = rx.observables.AsyncOnSubscribe[S, T]
+}

--- a/src/test/scala-2.11/rx/lang/scala/completeness/ObservableCompletenessKit.scala
+++ b/src/test/scala-2.11/rx/lang/scala/completeness/ObservableCompletenessKit.scala
@@ -198,8 +198,8 @@ class ObservableCompletenessKit extends CompletenessKit {
     // manually added entries for Java static methods
     "amb(Iterable[_ <: Observable[_ <: T]])" -> "amb(Observable[T]*)",
     "create(OnSubscribe[T])" -> "apply(Subscriber[T] => Unit)",
-    "create(SyncOnSubscribe[S, T])" -> "[use `SyncOnSubscribe.apply[S, T]`]",
-    "create(AsyncOnSubscribe[S, T])" -> "[use `AsyncOnSubscribe.apply[S, T]`]",
+    "create(SyncOnSubscribe[S, T])" -> "create(SyncOnSubscribe[S, T])",
+    "create(AsyncOnSubscribe[S, T])" -> "create(AsyncOnSubscribe[S, T])",
     "combineLatest(Observable[_ <: T1], Observable[_ <: T2], Func2[_ >: T1, _ >: T2, _ <: R])" -> "combineLatestWith(Observable[U])((T, U) => R)",
     "combineLatest(List[_ <: Observable[_ <: T]], FuncN[_ <: R])" -> "combineLatest(Iterable[Observable[T]])(Seq[T] => R)",
     "combineLatest(Iterable[_ <: Observable[_ <: T]], FuncN[_ <: R])" -> "combineLatest(Iterable[Observable[T]])(Seq[T] => R)",

--- a/src/test/scala-2.11/rx/lang/scala/completeness/ObservableCompletenessKit.scala
+++ b/src/test/scala-2.11/rx/lang/scala/completeness/ObservableCompletenessKit.scala
@@ -198,8 +198,8 @@ class ObservableCompletenessKit extends CompletenessKit {
     // manually added entries for Java static methods
     "amb(Iterable[_ <: Observable[_ <: T]])" -> "amb(Observable[T]*)",
     "create(OnSubscribe[T])" -> "apply(Subscriber[T] => Unit)",
-    "create(SyncOnSubscribe[S, T])" -> "[TODO]",
-    "create(AsyncOnSubscribe[S, T])" -> "[TODO]",
+    "create(SyncOnSubscribe[S, T])" -> "[use `SyncOnSubscribe.apply[S, T]`]",
+    "create(AsyncOnSubscribe[S, T])" -> "[use `AsyncOnSubscribe.apply[S, T]`]",
     "combineLatest(Observable[_ <: T1], Observable[_ <: T2], Func2[_ >: T1, _ >: T2, _ <: R])" -> "combineLatestWith(Observable[U])((T, U) => R)",
     "combineLatest(List[_ <: Observable[_ <: T]], FuncN[_ <: R])" -> "combineLatest(Iterable[Observable[T]])(Seq[T] => R)",
     "combineLatest(Iterable[_ <: Observable[_ <: T]], FuncN[_ <: R])" -> "combineLatest(Iterable[Observable[T]])(Seq[T] => R)",

--- a/src/test/scala-2.11/rx/lang/scala/completeness/ObservableCompletenessKit.scala
+++ b/src/test/scala-2.11/rx/lang/scala/completeness/ObservableCompletenessKit.scala
@@ -198,8 +198,6 @@ class ObservableCompletenessKit extends CompletenessKit {
     // manually added entries for Java static methods
     "amb(Iterable[_ <: Observable[_ <: T]])" -> "amb(Observable[T]*)",
     "create(OnSubscribe[T])" -> "apply(Subscriber[T] => Unit)",
-    "create(SyncOnSubscribe[S, T])" -> "create(SyncOnSubscribe[S, T])",
-    "create(AsyncOnSubscribe[S, T])" -> "create(AsyncOnSubscribe[S, T])",
     "combineLatest(Observable[_ <: T1], Observable[_ <: T2], Func2[_ >: T1, _ >: T2, _ <: R])" -> "combineLatestWith(Observable[U])((T, U) => R)",
     "combineLatest(List[_ <: Observable[_ <: T]], FuncN[_ <: R])" -> "combineLatest(Iterable[Observable[T]])(Seq[T] => R)",
     "combineLatest(Iterable[_ <: Observable[_ <: T]], FuncN[_ <: R])" -> "combineLatest(Iterable[Observable[T]])(Seq[T] => R)",

--- a/src/test/scala/rx/lang/scala/observables/AsyncOnSubscribeTests.scala
+++ b/src/test/scala/rx/lang/scala/observables/AsyncOnSubscribeTests.scala
@@ -3,12 +3,13 @@ package rx.lang.scala.observables
 import org.junit.Test
 import org.junit.Assert._
 import org.scalatest.junit.JUnitSuite
+import rx.lang.scala.observers.TestSubscriber
 import rx.lang.scala.{Notification, Observable}
 
 class AsyncOnSubscribeTests extends JUnitSuite {
 
   @Test
-  def testApply(): Unit = {
+  def testStateful(): Unit = {
     val last = 2000L
     val sut = AsyncOnSubscribe(() => 0L)((count,demand) =>
       if(count > last)
@@ -18,51 +19,47 @@ class AsyncOnSubscribeTests extends JUnitSuite {
         val next = Observable.from(count to max)
         (Notification.OnNext(next), max+1)
       }
-    )
+    ).toObservable
     assertEquals((0L to last).toList, sut.toBlocking.toList)
   }
 
   @Test
-  def testCreateStateful(): Unit = {
-    val last = 2000L
-    val sut = AsyncOnSubscribe.createStateful[Long, Long](() => 0L)((count,demand, obs) =>
-      if(count > last) {
-        obs.onCompleted()
-        count
-      } else {
-        val max = math.max(count + demand, last)
-        val next = Observable.from(count to max)
-        obs.onNext(next)
-        max+1
-      }
-    )
-    assertEquals((0L to last).toList, sut.toBlocking.toList)
-  }
-
-  @Test
-  def testApplyStateless(): Unit = {
-    val sut = AsyncOnSubscribe.applyStateless(r => Notification.OnNext(Observable.just(42).repeat(r)))
+  def testStateless(): Unit = {
+    val sut = AsyncOnSubscribe.stateless(r => Notification.OnNext(Observable.just(42).repeat(r))).toObservable
     assertEquals(List(42,42,42,42), sut.take(4).toBlocking.toList)
   }
 
   @Test
-  def testCreateStateless(): Unit = {
-    val sut = AsyncOnSubscribe.createStateless[Int]((r, obs) => obs.onNext(Observable.just(42).repeat(r)))
-    assertEquals(List(42,42,42,42), sut.take(4).toBlocking.toList)
-  }
-
-  @Test
-  def testApplySingleState(): Unit = {
+  def testSingleState(): Unit = {
     val random = math.random
-    val sut = AsyncOnSubscribe.applySingleState(() => random)((s,r) => Notification.OnNext(Observable.just(random.toString).repeat(r)))
+    val sut = AsyncOnSubscribe.singleState(() => random)((s,r) => Notification.OnNext(Observable.just(random.toString).repeat(r))).toObservable
     assertEquals(List(random.toString, random.toString), sut.take(2).toBlocking.toList)
   }
 
   @Test
   def testUnsubscribe(): Unit = {
     val sideEffect = new java.util.concurrent.atomic.AtomicBoolean(false)
-    val sut = AsyncOnSubscribe(() => ())((s,r) => (Notification.OnCompleted, s), onUnsubscribe = s => sideEffect.set(true))
+    val sut = AsyncOnSubscribe(() => ())((s,r) => (Notification.OnCompleted, s), onUnsubscribe = s => sideEffect.set(true)).toObservable
     sut.foreach(_ => ())
     assertEquals(true, sideEffect.get())
+  }
+
+  @Test
+  def testError(): Unit = {
+    val e = new IllegalStateException("Oh noes")
+    val sut = AsyncOnSubscribe(() => 0)((s,_) => (if(s>2) Notification.OnNext(Observable.just(s)) else Notification.OnError(e), s+1)).toObservable
+    val testSubscriber = TestSubscriber[Int]()
+    sut.subscribe(testSubscriber)
+    testSubscriber.assertError(e)
+  }
+
+  @Test
+  // Ensure that the generator is executed for each subscription
+  def testGenerator(): Unit = {
+    val sideEffectCount = new java.util.concurrent.atomic.AtomicInteger(0)
+    val sut = AsyncOnSubscribe(() => sideEffectCount.incrementAndGet())((s, _) => (Notification.OnCompleted, s)).toObservable
+    sut.toBlocking.toList
+    sut.toBlocking.toList
+    assertEquals(sideEffectCount.get(), 2)
   }
 }

--- a/src/test/scala/rx/lang/scala/observables/AsyncOnSubscribeTests.scala
+++ b/src/test/scala/rx/lang/scala/observables/AsyncOnSubscribeTests.scala
@@ -15,9 +15,9 @@ class AsyncOnSubscribeTests extends JUnitSuite {
       if(count > last)
         (Notification.OnCompleted, count)
       else {
-        val max = math.max(count + demand, last)
-        val next = Observable.from(count to max)
-        (Notification.OnNext(next), max+1)
+        val to = math.min(count+demand, last+1)
+        val next = Observable.from(count until to)
+        (Notification.OnNext(next), to)
       }
     ))
     assertEquals((0L to last).toList, o.toBlocking.toList)

--- a/src/test/scala/rx/lang/scala/observables/AsyncOnSubscribeTests.scala
+++ b/src/test/scala/rx/lang/scala/observables/AsyncOnSubscribeTests.scala
@@ -1,0 +1,68 @@
+package rx.lang.scala.observables
+
+import org.junit.Test
+import org.junit.Assert._
+import org.scalatest.junit.JUnitSuite
+import rx.lang.scala.{Notification, Observable}
+
+class AsyncOnSubscribeTests extends JUnitSuite {
+
+  @Test
+  def testApply(): Unit = {
+    val last = 2000L
+    val sut = AsyncOnSubscribe(() => 0L)((count,demand) =>
+      if(count > last)
+        (Notification.OnCompleted, count)
+      else {
+        val max = math.max(count + demand, last)
+        val next = Observable.from(count to max)
+        (Notification.OnNext(next), max+1)
+      }
+    )
+    assertEquals((0L to last).toList, sut.toBlocking.toList)
+  }
+
+  @Test
+  def testCreateStateful(): Unit = {
+    val last = 2000L
+    val sut = AsyncOnSubscribe.createStateful[Long, Long](() => 0L)((count,demand, obs) =>
+      if(count > last) {
+        obs.onCompleted()
+        count
+      } else {
+        val max = math.max(count + demand, last)
+        val next = Observable.from(count to max)
+        obs.onNext(next)
+        max+1
+      }
+    )
+    assertEquals((0L to last).toList, sut.toBlocking.toList)
+  }
+
+  @Test
+  def testApplyStateless(): Unit = {
+    val sut = AsyncOnSubscribe.applyStateless(r => Notification.OnNext(Observable.just(42).repeat(r)))
+    assertEquals(List(42,42,42,42), sut.take(4).toBlocking.toList)
+  }
+
+  @Test
+  def testCreateStateless(): Unit = {
+    val sut = AsyncOnSubscribe.createStateless[Int]((r, obs) => obs.onNext(Observable.just(42).repeat(r)))
+    assertEquals(List(42,42,42,42), sut.take(4).toBlocking.toList)
+  }
+
+  @Test
+  def testApplySingleState(): Unit = {
+    val random = math.random
+    val sut = AsyncOnSubscribe.applySingleState(() => random)((s,r) => Notification.OnNext(Observable.just(random.toString).repeat(r)))
+    assertEquals(List(random.toString, random.toString), sut.take(2).toBlocking.toList)
+  }
+
+  @Test
+  def testUnsubscribe(): Unit = {
+    val sideEffect = new java.util.concurrent.atomic.AtomicBoolean(false)
+    val sut = AsyncOnSubscribe(() => ())((s,r) => (Notification.OnCompleted, s), onUnsubscribe = s => sideEffect.set(true))
+    sut.foreach(_ => ())
+    assertEquals(true, sideEffect.get())
+  }
+}

--- a/src/test/scala/rx/lang/scala/observables/SyncOnSubscribeTests.scala
+++ b/src/test/scala/rx/lang/scala/observables/SyncOnSubscribeTests.scala
@@ -1,0 +1,61 @@
+package rx.lang.scala.observables
+
+import org.junit.Test
+import org.junit.Assert._
+import org.scalatest.junit.JUnitSuite
+import rx.lang.scala.{Notification, Observer}
+
+class SyncOnSubscribeTests extends JUnitSuite {
+
+  @Test
+  def testApply(): Unit = {
+    val sut = SyncOnSubscribe(() => 0)(count =>
+      if(count > 3)
+        (Notification.OnCompleted, count)
+      else
+        (Notification.OnNext(count), count+1)
+    )
+    assertEquals(List(0,1,2,3), sut.toBlocking.toList)
+  }
+
+  @Test
+  def testCreateStateful(): Unit = {
+    val sut = SyncOnSubscribe.createStateful(() => 0)((count, obs: Observer[_ >: Int]) => {
+      if(count > 3) {
+        obs.onCompleted()
+        count
+      } else {
+        obs.onNext(count)
+        count+1
+      }
+    })
+    assertEquals(List(0,1,2,3), sut.toBlocking.toList)
+  }
+
+  @Test
+  def testApplyStateless(): Unit = {
+    val sut = SyncOnSubscribe.applyStateless(() => Notification.OnNext(42))
+    assertEquals(List(42,42,42,42), sut.take(4).toBlocking.toList)
+  }
+
+  @Test
+  def testCreateStateless(): Unit = {
+    val sut = SyncOnSubscribe.createStateless[Int](obs => obs.onNext(42))
+    assertEquals(List(42,42,42,42), sut.take(4).toBlocking.toList)
+  }
+
+  @Test
+  def testApplySingleState(): Unit = {
+    val random = math.random
+    val sut = SyncOnSubscribe.applySingleState(() => random)(s => Notification.OnNext(s.toString))
+    assertEquals(List(random.toString, random.toString), sut.take(2).toBlocking.toList)
+  }
+
+  @Test
+  def testUnsubscribe(): Unit = {
+    val sideEffect = new java.util.concurrent.atomic.AtomicBoolean(false)
+    val sut = SyncOnSubscribe(() => ())(s => (Notification.OnCompleted, s), onUnsubscribe = s => sideEffect.set(true))
+    sut.foreach(_ => ())
+    assertEquals(true, sideEffect.get())
+  }
+}

--- a/src/test/scala/rx/lang/scala/observables/SyncOnSubscribeTests.scala
+++ b/src/test/scala/rx/lang/scala/observables/SyncOnSubscribeTests.scala
@@ -10,42 +10,42 @@ class SyncOnSubscribeTests extends JUnitSuite {
 
   @Test
   def testStateful(): Unit = {
-    val sut = Observable.create(SyncOnSubscribe(() => 0)(count =>
+    val o = Observable.create(SyncOnSubscribe(() => 0)(count =>
       if(count > 3)
         (Notification.OnCompleted, count)
       else
         (Notification.OnNext(count), count+1)
     ))
-    assertEquals(List(0,1,2,3), sut.toBlocking.toList)
+    assertEquals(List(0,1,2,3), o.toBlocking.toList)
   }
 
   @Test
   def testStateless(): Unit = {
-    val sut = Observable.create(SyncOnSubscribe.stateless(() => Notification.OnNext(42)))
-    assertEquals(List(42,42,42,42), sut.take(4).toBlocking.toList)
+    val o = Observable.create(SyncOnSubscribe.stateless(() => Notification.OnNext(42)))
+    assertEquals(List(42,42,42,42), o.take(4).toBlocking.toList)
   }
 
   @Test
   def testSingleState(): Unit = {
     val random = math.random
-    val sut = Observable.create(SyncOnSubscribe.singleState(() => random)(s => Notification.OnNext(s.toString)))
-    assertEquals(List(random.toString, random.toString), sut.take(2).toBlocking.toList)
+    val o = Observable.create(SyncOnSubscribe.singleState(() => random)(s => Notification.OnNext(s.toString)))
+    assertEquals(List(random.toString, random.toString), o.take(2).toBlocking.toList)
   }
 
   @Test
   def testUnsubscribe(): Unit = {
     val sideEffect = new java.util.concurrent.atomic.AtomicBoolean(false)
-    val sut = Observable.create(SyncOnSubscribe(() => ())(s => (Notification.OnCompleted, s), onUnsubscribe = s => sideEffect.set(true)))
-    sut.foreach(_ => ())
+    val o = Observable.create(SyncOnSubscribe(() => ())(s => (Notification.OnCompleted, s), onUnsubscribe = s => sideEffect.set(true)))
+    o.foreach(_ => ())
     assertEquals(true, sideEffect.get())
   }
 
   @Test
   def testError(): Unit = {
     val e = new IllegalStateException("Oh noes")
-    val sut = Observable.create(SyncOnSubscribe(() => 0)(s => (if(s>2) Notification.OnNext(s) else Notification.OnError(e), s+1)))
+    val o = Observable.create(SyncOnSubscribe(() => 0)(s => (if(s>2) Notification.OnNext(s) else Notification.OnError(e), s+1)))
     val testSubscriber = TestSubscriber[Int]()
-    sut.subscribe(testSubscriber)
+    o.subscribe(testSubscriber)
     testSubscriber.assertError(e)
   }
 
@@ -53,9 +53,9 @@ class SyncOnSubscribeTests extends JUnitSuite {
   // Ensure that the generator is executed for each subscription
   def testGenerator(): Unit = {
     val sideEffectCount = new java.util.concurrent.atomic.AtomicInteger(0)
-    val sut = Observable.create(SyncOnSubscribe(() => sideEffectCount.incrementAndGet())(s => (Notification.OnCompleted, s)))
-    sut.toBlocking.toList
-    sut.toBlocking.toList
+    val o = Observable.create(SyncOnSubscribe(() => sideEffectCount.incrementAndGet())(s => (Notification.OnCompleted, s)))
+    o.toBlocking.toList
+    o.toBlocking.toList
     assertEquals(sideEffectCount.get(), 2)
   }
 }

--- a/src/test/scala/rx/lang/scala/observables/SyncOnSubscribeTests.scala
+++ b/src/test/scala/rx/lang/scala/observables/SyncOnSubscribeTests.scala
@@ -10,32 +10,32 @@ class SyncOnSubscribeTests extends JUnitSuite {
 
   @Test
   def testStateful(): Unit = {
-    val sut = SyncOnSubscribe(() => 0)(count =>
+    val sut = Observable.create(SyncOnSubscribe(() => 0)(count =>
       if(count > 3)
         (Notification.OnCompleted, count)
       else
         (Notification.OnNext(count), count+1)
-    ).toObservable
+    ))
     assertEquals(List(0,1,2,3), sut.toBlocking.toList)
   }
 
   @Test
   def testStateless(): Unit = {
-    val sut = SyncOnSubscribe.stateless(() => Notification.OnNext(42)).toObservable
+    val sut = Observable.create(SyncOnSubscribe.stateless(() => Notification.OnNext(42)))
     assertEquals(List(42,42,42,42), sut.take(4).toBlocking.toList)
   }
 
   @Test
   def testSingleState(): Unit = {
     val random = math.random
-    val sut = SyncOnSubscribe.singleState(() => random)(s => Notification.OnNext(s.toString)).toObservable
+    val sut = Observable.create(SyncOnSubscribe.singleState(() => random)(s => Notification.OnNext(s.toString)))
     assertEquals(List(random.toString, random.toString), sut.take(2).toBlocking.toList)
   }
 
   @Test
   def testUnsubscribe(): Unit = {
     val sideEffect = new java.util.concurrent.atomic.AtomicBoolean(false)
-    val sut = SyncOnSubscribe(() => ())(s => (Notification.OnCompleted, s), onUnsubscribe = s => sideEffect.set(true)).toObservable
+    val sut = Observable.create(SyncOnSubscribe(() => ())(s => (Notification.OnCompleted, s), onUnsubscribe = s => sideEffect.set(true)))
     sut.foreach(_ => ())
     assertEquals(true, sideEffect.get())
   }
@@ -43,7 +43,7 @@ class SyncOnSubscribeTests extends JUnitSuite {
   @Test
   def testError(): Unit = {
     val e = new IllegalStateException("Oh noes")
-    val sut = SyncOnSubscribe(() => 0)(s => (if(s>2) Notification.OnNext(s) else Notification.OnError(e), s+1)).toObservable
+    val sut = Observable.create(SyncOnSubscribe(() => 0)(s => (if(s>2) Notification.OnNext(s) else Notification.OnError(e), s+1)))
     val testSubscriber = TestSubscriber[Int]()
     sut.subscribe(testSubscriber)
     testSubscriber.assertError(e)
@@ -53,7 +53,7 @@ class SyncOnSubscribeTests extends JUnitSuite {
   // Ensure that the generator is executed for each subscription
   def testGenerator(): Unit = {
     val sideEffectCount = new java.util.concurrent.atomic.AtomicInteger(0)
-    val sut = SyncOnSubscribe(() => sideEffectCount.incrementAndGet())(s => (Notification.OnCompleted, s)).toObservable
+    val sut = Observable.create(SyncOnSubscribe(() => sideEffectCount.incrementAndGet())(s => (Notification.OnCompleted, s)))
     sut.toBlocking.toList
     sut.toBlocking.toList
     assertEquals(sideEffectCount.get(), 2)

--- a/src/test/scala/rx/lang/scala/observables/SyncOnSubscribeTests.scala
+++ b/src/test/scala/rx/lang/scala/observables/SyncOnSubscribeTests.scala
@@ -3,59 +3,59 @@ package rx.lang.scala.observables
 import org.junit.Test
 import org.junit.Assert._
 import org.scalatest.junit.JUnitSuite
-import rx.lang.scala.{Notification, Observer}
+import rx.lang.scala.observers.TestSubscriber
+import rx.lang.scala.{Notification, Observable}
 
 class SyncOnSubscribeTests extends JUnitSuite {
 
   @Test
-  def testApply(): Unit = {
+  def testStateful(): Unit = {
     val sut = SyncOnSubscribe(() => 0)(count =>
       if(count > 3)
         (Notification.OnCompleted, count)
       else
         (Notification.OnNext(count), count+1)
-    )
+    ).toObservable
     assertEquals(List(0,1,2,3), sut.toBlocking.toList)
   }
 
   @Test
-  def testCreateStateful(): Unit = {
-    val sut = SyncOnSubscribe.createStateful(() => 0)((count, obs: Observer[_ >: Int]) => {
-      if(count > 3) {
-        obs.onCompleted()
-        count
-      } else {
-        obs.onNext(count)
-        count+1
-      }
-    })
-    assertEquals(List(0,1,2,3), sut.toBlocking.toList)
-  }
-
-  @Test
-  def testApplyStateless(): Unit = {
-    val sut = SyncOnSubscribe.applyStateless(() => Notification.OnNext(42))
+  def testStateless(): Unit = {
+    val sut = SyncOnSubscribe.stateless(() => Notification.OnNext(42)).toObservable
     assertEquals(List(42,42,42,42), sut.take(4).toBlocking.toList)
   }
 
   @Test
-  def testCreateStateless(): Unit = {
-    val sut = SyncOnSubscribe.createStateless[Int](obs => obs.onNext(42))
-    assertEquals(List(42,42,42,42), sut.take(4).toBlocking.toList)
-  }
-
-  @Test
-  def testApplySingleState(): Unit = {
+  def testSingleState(): Unit = {
     val random = math.random
-    val sut = SyncOnSubscribe.applySingleState(() => random)(s => Notification.OnNext(s.toString))
+    val sut = SyncOnSubscribe.singleState(() => random)(s => Notification.OnNext(s.toString)).toObservable
     assertEquals(List(random.toString, random.toString), sut.take(2).toBlocking.toList)
   }
 
   @Test
   def testUnsubscribe(): Unit = {
     val sideEffect = new java.util.concurrent.atomic.AtomicBoolean(false)
-    val sut = SyncOnSubscribe(() => ())(s => (Notification.OnCompleted, s), onUnsubscribe = s => sideEffect.set(true))
+    val sut = SyncOnSubscribe(() => ())(s => (Notification.OnCompleted, s), onUnsubscribe = s => sideEffect.set(true)).toObservable
     sut.foreach(_ => ())
     assertEquals(true, sideEffect.get())
+  }
+
+  @Test
+  def testError(): Unit = {
+    val e = new IllegalStateException("Oh noes")
+    val sut = SyncOnSubscribe(() => 0)(s => (if(s>2) Notification.OnNext(s) else Notification.OnError(e), s+1)).toObservable
+    val testSubscriber = TestSubscriber[Int]()
+    sut.subscribe(testSubscriber)
+    testSubscriber.assertError(e)
+  }
+
+  @Test
+  // Ensure that the generator is executed for each subscription
+  def testGenerator(): Unit = {
+    val sideEffectCount = new java.util.concurrent.atomic.AtomicInteger(0)
+    val sut = SyncOnSubscribe(() => sideEffectCount.incrementAndGet())(s => (Notification.OnCompleted, s)).toObservable
+    sut.toBlocking.toList
+    sut.toBlocking.toList
+    assertEquals(sideEffectCount.get(), 2)
   }
 }


### PR DESCRIPTION
See #219 for some discussion.

I implemented both option 2 (as `createX`) and 3 (as `applyX`), as 2 has some major annoyances when used from scala: type interferencing can't determine the `T` and the user requires at least 2 statements because you need to call the observer (you can't use a single expression).
The effects of this can be seen next to each other in the tests.

However, this causes duplicate very-similar functionality. If we want to avoid this I suggest we drop the java style `createX` methods and rename the `applyX` methods to `createX`.