### PR TITLE
Implement Observable.fromEmitter

### DIFF
--- a/src/main/scala/rx/lang/scala/Emitter.scala
+++ b/src/main/scala/rx/lang/scala/Emitter.scala
@@ -1,0 +1,44 @@
+package rx.lang.scala
+
+import rx.annotations.Experimental
+import rx.functions.Cancellable
+
+@Experimental
+trait Emitter[-T] extends Observer[T] {
+
+  private [scala] val asJavaEmitter: rx.Emitter[_ >: T] = new rx.Emitter[T] {
+    import JavaConverters.toScalaSubscription
+
+    override def requested(): Long = Emitter.this.requested
+    override def setCancellation(c: rx.functions.Cancellable): Unit = Emitter.this.setCancellation(() => c.cancel())
+    override def setSubscription(s: rx.Subscription): Unit = Emitter.this.setSubscription(s.asScalaSubscription)
+
+    override def onError(e: Throwable): Unit = Emitter.this.onError(e)
+    override def onCompleted(): Unit = Emitter.this.onCompleted()
+    override def onNext(t: T): Unit = Emitter.this.onNext(t)
+  }
+
+  def requested: Long
+
+  def setCancellation(onCancellation: () => Unit): Unit
+  def setSubscription(subscription: Subscription): Unit
+}
+
+object Emitter {
+  type BackpressureMode = rx.Emitter.BackpressureMode
+
+  private [scala] def apply[T](emitter: rx.Emitter[T]) : Emitter[T] = new Emitter[T] {
+    override val asJavaEmitter = emitter
+
+    override def requested = emitter.requested()
+
+    override def setCancellation(onCancellation: () => Unit): Unit = asJavaEmitter.setCancellation(new Cancellable {
+      override def cancel() = onCancellation()
+    })
+    override def setSubscription(subscription: Subscription): Unit = asJavaEmitter.setSubscription(subscription.asJavaSubscription)
+
+    override def onNext(value: T): Unit = asJavaEmitter.onNext(value)
+    override def onError(error: Throwable): Unit = asJavaEmitter.onError(error)
+    override def onCompleted(): Unit = asJavaEmitter.onCompleted()
+  }
+}

--- a/src/main/scala/rx/lang/scala/JavaConverters.scala
+++ b/src/main/scala/rx/lang/scala/JavaConverters.scala
@@ -84,6 +84,9 @@ trait DecorateAsJava {
   implicit def toJavaObserver[T](s: Observer[T]): AsJava[rx.Observer[_ >: T]] =
     new AsJava(s.asJavaObserver)
 
+  implicit def toJavaEmitter[T](s: Emitter[T]): AsJava[rx.Emitter[_ >: T]] =
+    new AsJava(s.asJavaEmitter)
+
   implicit def toJavaObservable[T](s: Observable[T]): AsJava[rx.Observable[_ <: T]] =
     new AsJava(s.asJavaObservable)
 
@@ -123,6 +126,9 @@ trait DecorateAsScala {
 
   implicit def toScalaObserver[T](s: rx.Observer[_ >: T]): AsScala[Observer[T]] =
     new AsScala(Observer(s))
+
+  implicit def toScalaEmitter[T](s: rx.Emitter[_ >: T]): AsScala[Emitter[T]] =
+    new AsScala(Emitter(s))
 
   implicit def toScalaObservable[T](s: rx.Observable[_ <: T]): AsScala[Observable[T]] = {
     val obs = new Observable[T] {

--- a/src/main/scala/rx/lang/scala/Observable.scala
+++ b/src/main/scala/rx/lang/scala/Observable.scala
@@ -4965,6 +4965,12 @@ object Observable {
   @Experimental
   def create[S,T](asyncOnSubscribe: AsyncOnSubscribe[S,T]): Observable[T] = toScalaObservable[T](rx.Observable.create(asyncOnSubscribe))
 
+  @Experimental
+  def fromEmitter[T](emitter: Emitter[T] => Unit, backpressureMode: Emitter.BackpressureMode): Observable[T] = {
+    import JavaConverters.toScalaEmitter
+    toScalaObservable[T](rx.Observable.fromEmitter[T]((e: rx.Emitter[T]) => emitter(e.asScala), backpressureMode))
+  }
+
   /**
    * Returns an Observable that will execute the specified function when someone subscribes to it.
    *

--- a/src/test/scala-2.11/rx/lang/scala/completeness/ObservableCompletenessKit.scala
+++ b/src/test/scala-2.11/rx/lang/scala/completeness/ObservableCompletenessKit.scala
@@ -219,7 +219,7 @@ class ObservableCompletenessKit extends CompletenessKit {
     "from(Future[_ <: T])" -> fromFuture,
     "from(Future[_ <: T], Long, TimeUnit)" -> fromFuture,
     "from(Future[_ <: T], Scheduler)" -> fromFuture,
-    "fromEmitter(Action1[Emitter[T]], BackpressureMode)" -> "[TODO]",
+    "fromEmitter(Action1[Emitter[T]], BackpressureMode)" -> "fromEmitter(Emitter[T] => Unit, BackpressureMode)",
     "just(T)" -> "just(T*)",
     "merge(Observable[_ <: T], Observable[_ <: T])" -> "merge(Observable[U])",
     "merge(Observable[_ <: Observable[_ <: T]])" -> "flatten(<:<[Observable[T], Observable[Observable[U]]])",

--- a/src/test/scala/rx/lang/scala/ConstructorTest.scala
+++ b/src/test/scala/rx/lang/scala/ConstructorTest.scala
@@ -18,6 +18,11 @@ import scala.language.postfixOps
 import org.junit.Assert._
 import org.junit.Test
 import org.scalatest.junit.JUnitSuite
+import rx.Emitter.BackpressureMode
+import rx.lang.scala.observers.TestSubscriber
+import rx.lang.scala.subjects.PublishSubject
+
+import scala.concurrent.duration._
 
 class ConstructorTest extends JUnitSuite {
 
@@ -31,5 +36,96 @@ class ConstructorTest extends JUnitSuite {
     val zs = Observable.just(1,2,3).toBlocking.toList
     assertEquals(List(1,2,3), xs)
 
+  }
+
+  @Test def testFromEmitter(): Unit = {
+    val max = 200
+
+    trait Callback {
+      def newValue(v: Int): Unit
+      def complete(): Unit
+    }
+
+    def callbackStyleAPI(callback: Callback): Unit = {
+      new Thread(new Runnable {
+        override def run(): Unit = {
+          Range(0, max).foreach(callback.newValue)
+          callback.complete()
+        }
+      }).start()
+    }
+
+    val o = Observable.fromEmitter[Int](e => {
+      callbackStyleAPI(new Callback {
+        override def newValue(v: Int): Unit = e.onNext(v)
+        override def complete(): Unit = e.onCompleted()
+      })
+    }, BackpressureMode.BUFFER)
+
+    assertEquals(Range(0,max).toList, o.toBlocking.toList)
+  }
+
+  @Test def testFromEmitterError(): Unit = {
+    val ex = new RuntimeException("Oopsie")
+
+    trait Callback {
+      def error(e: Throwable): Unit
+    }
+
+    def callbackStyleAPI(callback: Callback): Unit = {
+      new Thread(new Runnable {
+        override def run(): Unit = callback.error(ex)
+      }).start()
+    }
+
+    val o = Observable.fromEmitter[Int](e => {
+      callbackStyleAPI(new Callback {
+        override def error(err: Throwable) = e.onError(err)
+      })
+    }, BackpressureMode.BUFFER)
+
+    val testSubscriber = TestSubscriber[Int]()
+    o.subscribe(testSubscriber)
+    testSubscriber.awaitTerminalEvent(500.millis)
+    testSubscriber.assertError(ex)
+  }
+
+  @Test def testFromEmitterCancel(): Unit = {
+    val stopSubject = Subject[Unit]()
+    val testSubscriber = TestSubscriber[Unit]()
+    stopSubject.subscribe(testSubscriber)
+
+    trait Callback {
+      def newValue(v: Int): Unit
+    }
+
+    def callbackStyleAPI(callback: Callback): () => Unit = {
+      @volatile var stop = false
+      val t = new Thread(new Runnable {
+        override def run(): Unit = {
+          var i = 0
+          while (!stop) {
+            callback.newValue(i)
+            i += 1
+          }
+          stopSubject.onNext(())
+          stopSubject.onCompleted()
+        }
+      })
+      t.start()
+      () => { stop = true }
+    }
+
+
+    val values = Observable.fromEmitter[Int](e => {
+      val stopF = callbackStyleAPI(new Callback {
+        override def newValue(v: Int) = e.onNext(v)
+      })
+      e.setCancellation(stopF)
+    },BackpressureMode.DROP)
+
+    assertEquals(200, values.take(200).toBlocking.toList.size)
+    testSubscriber.awaitTerminalEvent(100.millis)
+    testSubscriber.assertValue(())
   }
 }


### PR DESCRIPTION
This was still missing in the Scala API.

I haven't encountered a lot of use for it within the scala ecosystem (since callback are uncommon), but it's useful when integrating non-scala JVM libraries.

I'll add documentation if this structure is found to be OK 